### PR TITLE
Redesign: cinematic multi-engine search portal (dark theme, EN/RU, 30+ engines)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to SearchForYou
+
+Thanks for your interest in improving **SearchForYou**! This is a lightweight,
+dependency-free static site, so contributing is quick and friendly.
+
+## Getting started
+
+1. **Fork** the repository and **clone** your fork.
+2. Open `index.html` directly in a browser, or serve the folder locally:
+   ```bash
+   # Python
+   python3 -m http.server 8080
+   # or Node
+   npx serve .
+   ```
+   Then visit `http://localhost:8080`.
+
+> Serving over `http(s)://` is recommended so the icon CDNs and clipboard
+> features behave exactly as in production.
+
+## Project layout
+
+| File | What lives here |
+| --- | --- |
+| `index.html` | Markup and structure |
+| `styles.css` | Design tokens, themes, animations |
+| `script.js` | App logic, rendering, canvas, shared-link sequence |
+| `engines.js` | Search engine catalogue and categories |
+| `i18n.js` | Translations (English / Russian) |
+
+## Ways to contribute
+
+### Add a search engine
+Add an entry to the `SEARCH_ENGINES` array in `engines.js`. Verify the search
+URL works by appending an encoded query to it. Prefer engines that respect user
+privacy, and pick the right category. Use a [Simple Icons](https://simpleicons.org)
+slug when one exists, otherwise set `icon: null` for a lettered badge.
+
+### Add or improve a translation
+All user-facing strings live in `i18n.js`. Keep keys identical across languages.
+To add a new language, create a new object alongside `en` and `ru` and add it to
+the language switcher logic in `script.js`.
+
+### Design & animations
+CSS is organized into clearly labelled sections. Keep both the **dark** and
+**light** themes looking great, and make sure animations are gated behind
+`prefers-reduced-motion` where appropriate.
+
+## Guidelines
+
+- **No build step.** Keep the project pure HTML/CSS/JS — it must run straight from
+  GitHub Pages.
+- **No tracking.** Do not add analytics, cookies, or any backend calls.
+- **Test both themes and both languages** before opening a PR.
+- **Check `prefers-reduced-motion`** still produces a usable experience.
+- Keep code style consistent with the surrounding files.
+
+## Pull requests
+
+1. Create a feature branch.
+2. Commit with clear, descriptive messages.
+3. Push and open a Pull Request describing **what** changed and **why**.
+
+Happy hacking! 🔍

--- a/README.md
+++ b/README.md
@@ -1,102 +1,134 @@
-# SearchForYou 🔍
+<div align="center">
 
-**Умная, дружелюбная и слегка ироничная платформа, помогающая людям находить ответы самостоятельно через поисковые системы.**
+# 🔍 SearchForYou
 
-> *«Почему бы тебе просто не загуглить?»* — теперь можно ответить ссылкой на **SearchForYou**, где всё происходит как в кино!
+### The search portal that does it with style.
 
-![SearchForYou Interface](https://github.com/user-attachments/assets/0fbe41d5-993c-4ec1-a6bf-94b1da9e84f5)
+**One portal. 25+ search engines. Zero tracking.**
+From Google to indie old-web gems like *Marginalia* and *Wiby* — pick an engine, search with cinematic flair, and share links that play an epic search animation before landing on the results.
 
-## ✨ Особенности
+[**▶ Live demo**](https://vadim-khristenko.github.io/Search-for-YOU/) · [Report a bug](https://github.com/Vadim-Khristenko/Search-for-YOU/issues) · [Request a feature](https://github.com/Vadim-Khristenko/Search-for-YOU/issues)
 
-- **🎬 Эпические анимации** — Впечатляющие эффекты поиска с радаром, сканированием и финальным "ОТВЕТ НАЙДЕН!"
-- **🔗 Shareable-ссылки** — Создавайте ссылки с автоматической анимацией для друзей
-- **🎯 Поддержка всех популярных поисковиков** — Google, Yandex, Bing, DuckDuckGo
-- **🌐 Custom URL** — Направляйте на любую нужную страницу
-- **📱 Адаптивный дизайн** — Отлично работает на всех устройствах
-- **⚡ Высокая производительность** — Всего 32KB, быстрая загрузка
+`HTML` · `CSS` · `Vanilla JS` · `No build step` · `GitHub Pages ready`
 
-![Mobile Design](https://github.com/user-attachments/assets/c5f5cfeb-e842-4b0f-8c5f-53d985ab7ed6)
-
-## 🚀 Использование
-
-### 1. Обычный поиск
-1. Введите ваш вопрос в поле поиска
-2. Выберите поисковую систему 
-3. Нажмите "Найти ответ"
-4. Перейдите к результатам поиска
-
-### 2. Создание shareable-ссылки
-1. Введите вопрос
-2. Выберите поисковик (или укажите custom URL)
-3. Нажмите "Поделиться запросом"
-4. Скопируйте ссылку и отправьте друзьям
-
-### 3. Эффект для получателей
-При открытии shared-ссылки запускается:
-- ⌨️ **Анимация печати** — текст появляется по буквам
-- 🔎 **Поисковая анимация** — радар, сканирование, эффекты
-- ✅ **Финал "ОТВЕТ НАЙДЕН!"** — яркая вспышка и успех
-- 🔄 **Автоматический редирект** — переход к результатам
-
-## 🛠️ Технические детали
-
-- **Технологии**: HTML5, CSS3, Vanilla JavaScript
-- **Размер**: 32KB (HTML + CSS + JS)
-- **Зависимости**: Только Google Fonts (Inter)
-- **Совместимость**: Все современные браузеры
-- **Hosting**: GitHub Pages ready
-
-## 📦 Развертывание
-
-Проект полностью статический и готов для GitHub Pages:
-
-1. Fork этого репозитория
-2. Включите GitHub Pages в настройках
-3. Выберите source: `main` branch
-4. Ваш сайт будет доступен по адресу: `https://username.github.io/Search-for-YOU`
-
-## 🎨 Кастомизация
-
-### Изменение поисковых систем
-Отредактируйте объект `SEARCH_ENGINES` в `script.js`:
-
-```javascript
-const SEARCH_ENGINES = {
-    myengine: {
-        name: 'My Engine',
-        url: 'https://myengine.com/search?q=',
-        encode: true
-    }
-};
-```
-
-### Изменение анимаций
-Модифицируйте CSS анимации в `styles.css` или массив `LOADING_MESSAGES` в `script.js`.
-
-### Изменение дизайна
-Настройте CSS переменные в `:root` секции `styles.css`:
-
-```css
-:root {
-    --primary-color: #0070f3;
-    --background: #ffffff;
-    /* другие цвета... */
-}
-```
-
-## 📄 Лицензия
-
-MIT License - смотрите [LICENSE](LICENSE) для деталей.
-
-## 🤝 Вклад
-
-Contributions welcome! Пожалуйста:
-1. Fork проект
-2. Создайте feature branch
-3. Commit изменения
-4. Push в branch  
-5. Откройте Pull Request
+</div>
 
 ---
 
-**SearchForYou** — потому что вы способны найти это сами. Но мы поможем с эффектами! ✨
+## ✨ Highlights
+
+- **🌑 Dark-first design** — a deep, glassmorphic dark theme by default, with a polished light theme one tap away. Your choice is remembered.
+- **🌍 Bilingual UI** — full **English** and **Russian** localization with an instant language switch.
+- **🛰️ 25+ search engines** — neatly grouped into **Mainstream**, **Privacy**, **AI**, **Academic**, **Indie / Old Web** and **Developer** categories.
+- **🎬 Cinematic shareable links** — reply to *"just google it"* with a link that types out the query, sweeps a radar, and reveals a triumphant **"ANSWER FOUND!"** before redirecting.
+- **🎲 Surprise me** — feeling adventurous? Let the engine roulette pick one for you.
+- **🪐 Living background** — an animated, mouse-reactive node network on `<canvas>`, plus drifting aurora blobs.
+- **🧩 Icon-rich** — [Lucide](https://lucide.dev) for the UI and [Simple Icons](https://simpleicons.org) for authentic engine logos.
+- **🔒 Privacy by design** — pure static site. No backend, no cookies, no analytics. Everything runs in your browser.
+- **♿ Thoughtful** — respects `prefers-reduced-motion`, keyboard-friendly (press `/` to focus search), and fully responsive.
+
+## 🛰️ Included search engines
+
+| Category | Engines |
+| --- | --- |
+| **Mainstream** | Google, Bing, Yandex, DuckDuckGo, Baidu |
+| **Privacy** | Brave Search, Startpage, Ecosia, Qwant, Mojeek, SearXNG, Swisscows |
+| **AI** | Perplexity, Phind, You.com, Andi |
+| **Academic** | Wikipedia, WolframAlpha, Google Scholar, arXiv, Semantic Scholar, PubMed |
+| **Indie / Old Web** | Marginalia, Wiby, Stract, Yep, Million Short, Presearch |
+| **Developer** | GitHub, Stack Overflow, MDN, DevDocs, Hacker News |
+
+## 🚀 Usage
+
+### Search
+1. Type your query.
+2. Pick a category and a search engine (or hit **Surprise me**).
+3. Press **Find the answer** — you're redirected to the results.
+
+### Create a shareable link
+1. Type your query and choose an engine (or set a **Custom URL**).
+2. Press **Share query**.
+3. Copy the generated link and send it to anyone.
+
+### What the recipient sees
+Opening a shared link triggers the full sequence:
+- ⌨️ **Typing animation** — the query appears character by character
+- 🛰️ **Radar search** — sweeping radar with pinging detections and a progress bar
+- ✅ **"ANSWER FOUND!"** — a satisfying success reveal
+- 🔁 **Auto-redirect** — straight to the real results
+
+> Users with `prefers-reduced-motion` enabled skip straight to the results.
+
+## 🛠️ Tech & structure
+
+| File | Purpose |
+| --- | --- |
+| `index.html` | Markup and semantic structure |
+| `styles.css` | Design tokens, dark/light themes, animations |
+| `script.js` | App logic, rendering, canvas background, shared-link sequence |
+| `engines.js` | Search engine catalogue and categories |
+| `i18n.js` | English / Russian translations |
+| `manifest.json` | PWA metadata |
+
+- **Stack:** HTML5, CSS3, vanilla JavaScript — no frameworks, no build step.
+- **Runtime dependencies (CDN):** Google Fonts, [Lucide](https://lucide.dev) icons, [Simple Icons](https://simpleicons.org) logos.
+- **Compatibility:** all modern browsers.
+
+## 📦 Deployment (GitHub Pages)
+
+This project is fully static and ready for GitHub Pages:
+
+1. Fork this repository.
+2. Go to **Settings → Pages**.
+3. Under **Build and deployment**, set source to **Deploy from a branch**.
+4. Choose the `main` branch and the `/ (root)` folder, then **Save**.
+5. Your site goes live at `https://<username>.github.io/Search-for-YOU/`.
+
+No build, no CI, no configuration required.
+
+## 🎨 Customization
+
+### Add or edit a search engine
+Edit the `SEARCH_ENGINES` array in [`engines.js`](engines.js):
+
+```javascript
+{
+    id: 'myengine',
+    name: 'My Engine',
+    url: 'https://myengine.com/search?q=', // query is appended here
+    encode: true,                          // URL-encode the query
+    cat: 'indie',                          // main | privacy | ai | academic | indie | dev
+    color: '#a855f7',                      // brand color for the badge glow
+    icon: null                             // Simple Icons slug, or null for a lettered badge
+}
+```
+
+### Theme colors
+Tweak the brand gradient and theme tokens in the `:root` and `[data-theme]` blocks of [`styles.css`](styles.css):
+
+```css
+:root {
+    --grad-1: #6366f1;
+    --grad-2: #a855f7;
+    --grad-3: #22d3ee;
+}
+```
+
+### Translations
+Add or adjust strings in [`i18n.js`](i18n.js) under the `en` and `ru` objects. Add a new language by adding a key alongside them.
+
+## 🤝 Contributing
+
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+## 📄 License
+
+Released under the [MIT License](LICENSE).
+
+---
+
+<div align="center">
+
+**SearchForYou** — because you can find it yourself. We just make it look incredible. ✨
+
+</div>

--- a/engines.js
+++ b/engines.js
@@ -1,0 +1,76 @@
+/* ============================================================
+   SearchForYou — search engine catalogue
+   Each engine: { id, name, url, encode, cat, color, icon }
+   - url      : query is appended to this string
+   - encode   : whether to encodeURIComponent the query
+   - cat      : category id (see CATEGORIES)
+   - color    : brand color used for the badge glow / fallback
+   - icon     : Simple Icons slug (https://cdn.simpleicons.org/<icon>)
+                or null to render a lettered monogram instead
+   ============================================================ */
+
+const CATEGORIES = [
+    { id: 'all',      icon: 'layout-grid' },
+    { id: 'main',     icon: 'globe' },
+    { id: 'privacy',  icon: 'shield-check' },
+    { id: 'ai',       icon: 'sparkles' },
+    { id: 'academic', icon: 'graduation-cap' },
+    { id: 'indie',    icon: 'compass' },
+    { id: 'dev',      icon: 'code-2' }
+];
+
+const SEARCH_ENGINES = [
+    /* ---------- Mainstream ---------- */
+    { id: 'google',     name: 'Google',        url: 'https://www.google.com/search?q=',            encode: true, cat: 'main',     color: '#4285F4', icon: 'google' },
+    { id: 'bing',       name: 'Bing',          url: 'https://www.bing.com/search?q=',              encode: true, cat: 'main',     color: '#0078D4', icon: 'microsoftbing' },
+    { id: 'yandex',     name: 'Yandex',        url: 'https://yandex.com/search/?text=',            encode: true, cat: 'main',     color: '#FF0000', icon: 'yandex' },
+    { id: 'duckduckgo', name: 'DuckDuckGo',    url: 'https://duckduckgo.com/?q=',                  encode: true, cat: 'main',     color: '#DE5833', icon: 'duckduckgo' },
+    { id: 'baidu',      name: 'Baidu',         url: 'https://www.baidu.com/s?wd=',                 encode: true, cat: 'main',     color: '#2932E1', icon: 'baidu' },
+
+    /* ---------- Privacy ---------- */
+    { id: 'brave',      name: 'Brave Search',  url: 'https://search.brave.com/search?q=',          encode: true, cat: 'privacy',  color: '#FB542B', icon: 'brave' },
+    { id: 'startpage',  name: 'Startpage',     url: 'https://www.startpage.com/sp/search?query=',  encode: true, cat: 'privacy',  color: '#6573FF', icon: 'startpage' },
+    { id: 'ecosia',     name: 'Ecosia',        url: 'https://www.ecosia.org/search?q=',            encode: true, cat: 'privacy',  color: '#56AC58', icon: 'ecosia' },
+    { id: 'qwant',      name: 'Qwant',         url: 'https://www.qwant.com/?q=',                   encode: true, cat: 'privacy',  color: '#5C97FF', icon: 'qwant' },
+    { id: 'mojeek',     name: 'Mojeek',        url: 'https://www.mojeek.com/search?q=',            encode: true, cat: 'privacy',  color: '#A4C639', icon: null },
+    { id: 'searxng',    name: 'SearXNG',       url: 'https://searx.be/search?q=',                  encode: true, cat: 'privacy',  color: '#3050FF', icon: 'searxng' },
+    { id: 'swisscows',  name: 'Swisscows',     url: 'https://swisscows.com/en/web?query=',         encode: true, cat: 'privacy',  color: '#D81B60', icon: null },
+
+    /* ---------- AI ---------- */
+    { id: 'perplexity', name: 'Perplexity',    url: 'https://www.perplexity.ai/search?q=',         encode: true, cat: 'ai',       color: '#20B8CD', icon: 'perplexity' },
+    { id: 'phind',      name: 'Phind',         url: 'https://www.phind.com/search?q=',             encode: true, cat: 'ai',       color: '#10A37F', icon: null },
+    { id: 'you',        name: 'You.com',       url: 'https://you.com/search?q=',                   encode: true, cat: 'ai',       color: '#9D4EDD', icon: null },
+    { id: 'andi',       name: 'Andi',          url: 'https://andisearch.com/?q=',                  encode: true, cat: 'ai',       color: '#FF6B6B', icon: null },
+
+    /* ---------- Academic & Knowledge ---------- */
+    { id: 'wikipedia',  name: 'Wikipedia',     url: 'https://en.wikipedia.org/w/index.php?search=',encode: true, cat: 'academic', color: '#A2A9B1', icon: 'wikipedia' },
+    { id: 'wolfram',    name: 'WolframAlpha',  url: 'https://www.wolframalpha.com/input?i=',       encode: true, cat: 'academic', color: '#DD1100', icon: 'wolframalpha' },
+    { id: 'scholar',    name: 'Scholar',       url: 'https://scholar.google.com/scholar?q=',       encode: true, cat: 'academic', color: '#4285F4', icon: 'googlescholar' },
+    { id: 'arxiv',      name: 'arXiv',         url: 'https://arxiv.org/abs/',                      encode: true, cat: 'academic', color: '#B31B1B', icon: 'arxiv' },
+    { id: 'semantic',   name: 'Semantic',      url: 'https://www.semanticscholar.org/search?q=',   encode: true, cat: 'academic', color: '#1857B6', icon: 'semanticscholar' },
+    { id: 'pubmed',     name: 'PubMed',        url: 'https://pubmed.ncbi.nlm.nih.gov/?term=',      encode: true, cat: 'academic', color: '#326295', icon: null },
+
+    /* ---------- Indie / Old Web ---------- */
+    { id: 'marginalia', name: 'Marginalia',    url: 'https://search.marginalia.nu/search?query=',  encode: true, cat: 'indie',    color: '#7E22CE', icon: null },
+    { id: 'wiby',       name: 'Wiby',          url: 'https://wiby.me/?q=',                         encode: true, cat: 'indie',    color: '#3B82F6', icon: null },
+    { id: 'stract',     name: 'Stract',        url: 'https://stract.com/search?q=',                encode: true, cat: 'indie',    color: '#F59E0B', icon: null },
+    { id: 'yep',        name: 'Yep',           url: 'https://yep.com/web?q=',                      encode: true, cat: 'indie',    color: '#FF8A00', icon: null },
+    { id: 'millionshort',name:'Million Short', url: 'https://millionshort.com/search?keywords=',   encode: true, cat: 'indie',    color: '#22C55E', icon: null },
+    { id: 'presearch',  name: 'Presearch',     url: 'https://presearch.com/search?q=',             encode: true, cat: 'indie',    color: '#1A56DB', icon: null },
+
+    /* ---------- Developer ---------- */
+    { id: 'github',     name: 'GitHub',        url: 'https://github.com/search?q=',                encode: true, cat: 'dev',      color: '#8B95A5', icon: 'github' },
+    { id: 'stackoverflow',name:'Stack Overflow',url:'https://stackoverflow.com/search?q=',         encode: true, cat: 'dev',      color: '#F48024', icon: 'stackoverflow' },
+    { id: 'mdn',        name: 'MDN',           url: 'https://developer.mozilla.org/en-US/search?q=',encode: true, cat: 'dev',     color: '#000000', icon: 'mdnwebdocs' },
+    { id: 'devdocs',    name: 'DevDocs',       url: 'https://devdocs.io/#q=',                      encode: true, cat: 'dev',      color: '#3B6E22', icon: 'devdotto' },
+    { id: 'hackernews', name: 'HN Search',     url: 'https://hn.algolia.com/?q=',                  encode: true, cat: 'dev',      color: '#FF6600', icon: 'ycombinator' }
+];
+
+/* Quick lookup by id */
+const ENGINE_MAP = Object.fromEntries(SEARCH_ENGINES.map(e => [e.id, e]));
+
+if (typeof window !== 'undefined') {
+    window.CATEGORIES = CATEGORIES;
+    window.SEARCH_ENGINES = SEARCH_ENGINES;
+    window.ENGINE_MAP = ENGINE_MAP;
+}

--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,125 @@
+/* ============================================================
+   SearchForYou — internationalization (EN / RU)
+   Keys map to [data-i18n] (textContent) and
+   [data-i18n-placeholder] (placeholder attr) in the markup.
+   ============================================================ */
+
+const I18N = {
+    en: {
+        'hero.badge': '25+ search engines · one portal',
+        'hero.titleA': 'Search',
+        'hero.titleB': 'ForYou',
+        'hero.tagline': 'Because you can find it yourself — but we make it cinematic.',
+        'hero.sub': 'Mainstream, privacy, AI, academic & indie old-web search in one place.',
+
+        'search.placeholder': 'Type anything…',
+        'engines.heading': 'Choose your engine',
+        'engines.surprise': 'Surprise me',
+
+        'cat.all': 'All',
+        'cat.main': 'Mainstream',
+        'cat.privacy': 'Privacy',
+        'cat.ai': 'AI',
+        'cat.academic': 'Academic',
+        'cat.indie': 'Indie / Old Web',
+        'cat.dev': 'Developer',
+
+        'custom.summary': 'Or point to a custom URL',
+        'actions.search': 'Find the answer',
+        'actions.share': 'Share query',
+
+        'share.heading': 'Your shareable link',
+        'share.copy': 'Copy',
+        'share.copied': 'Copied!',
+        'share.description': "Send it to anyone — they'll get the full cinematic search animation before landing on the results.",
+        'share.native': 'Share',
+
+        'feat.privacy.t': 'Privacy first',
+        'feat.privacy.d': 'No tracking, no cookies, no backend. Pure static, runs entirely in your browser.',
+        'feat.engines.t': '25+ engines',
+        'feat.engines.d': 'Mainstream, privacy, AI, academic and indie old-web search — all curated for you.',
+        'feat.fun.t': 'Cinematic links',
+        'feat.fun.d': 'Reply to "just google it" with a link that plays an epic search sequence.',
+
+        'success.title': 'ANSWER FOUND!',
+        'success.subtitle': 'Redirecting you now…',
+
+        'footer.text': 'SearchForYou — because you can find it yourself. We just make it look incredible.',
+        'footer.made': 'Crafted with',
+
+        'toast.needQuery': 'Type something to search first 🙂',
+        'toast.copied': 'Link copied to clipboard!',
+        'toast.copyFail': "Couldn't copy — select the link manually.",
+        'toast.surprise': 'Engine roulette →',
+        'toast.shared': 'Shared!',
+
+        'loading.0': 'Searching…',
+        'loading.1': 'Scanning the web…',
+        'loading.2': 'Crawling indexes…',
+        'loading.3': 'Ranking results…',
+        'loading.4': 'Match found!',
+
+        'lang.name': 'EN'
+    },
+
+    ru: {
+        'hero.badge': '25+ поисковиков · один портал',
+        'hero.titleA': 'Search',
+        'hero.titleB': 'ForYou',
+        'hero.tagline': 'Потому что вы способны найти это сами — а мы сделаем это кинематографично.',
+        'hero.sub': 'Массовые, приватные, ИИ, академические и инди-поисковики старого веба — в одном месте.',
+
+        'search.placeholder': 'Введите что угодно…',
+        'engines.heading': 'Выберите поисковик',
+        'engines.surprise': 'Удиви меня',
+
+        'cat.all': 'Все',
+        'cat.main': 'Массовые',
+        'cat.privacy': 'Приватность',
+        'cat.ai': 'ИИ',
+        'cat.academic': 'Академические',
+        'cat.indie': 'Инди / Старый веб',
+        'cat.dev': 'Для разработчиков',
+
+        'custom.summary': 'Или укажите свою ссылку (Custom URL)',
+        'actions.search': 'Найти ответ',
+        'actions.share': 'Поделиться запросом',
+
+        'share.heading': 'Ваша ссылка для отправки',
+        'share.copy': 'Копировать',
+        'share.copied': 'Скопировано!',
+        'share.description': 'Отправьте её кому угодно — получатель увидит эпическую анимацию поиска перед переходом к результатам.',
+        'share.native': 'Поделиться',
+
+        'feat.privacy.t': 'Приватность прежде всего',
+        'feat.privacy.d': 'Без трекинга, cookies и бэкенда. Чистая статика, всё работает прямо в браузере.',
+        'feat.engines.t': '25+ поисковиков',
+        'feat.engines.d': 'Массовые, приватные, ИИ, академические и инди-поисковики — всё подобрано для вас.',
+        'feat.fun.t': 'Кинематографичные ссылки',
+        'feat.fun.d': 'Ответьте на «да загугли сам» ссылкой, запускающей эпическую сцену поиска.',
+
+        'success.title': 'ОТВЕТ НАЙДЕН!',
+        'success.subtitle': 'Перенаправляем вас…',
+
+        'footer.text': 'SearchForYou — потому что вы способны найти это сами. А мы сделаем это красиво.',
+        'footer.made': 'Сделано с',
+
+        'toast.needQuery': 'Сначала введите запрос 🙂',
+        'toast.copied': 'Ссылка скопирована в буфер обмена!',
+        'toast.copyFail': 'Не удалось скопировать — выделите ссылку вручную.',
+        'toast.surprise': 'Рулетка поисковиков →',
+        'toast.shared': 'Отправлено!',
+
+        'loading.0': 'Поиск ответа…',
+        'loading.1': 'Сканирую интернет…',
+        'loading.2': 'Обхожу индексы…',
+        'loading.3': 'Ранжирую результаты…',
+        'loading.4': 'Совпадение найдено!',
+
+        'lang.name': 'RU'
+    }
+};
+
+if (typeof window !== 'undefined') {
+    window.I18N = I18N;
+}

--- a/index.html
+++ b/index.html
@@ -1,153 +1,212 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="en" data-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SearchForYou — умный поиск с эффектами</title>
-    <meta name="description" content="Направляем к поиску с юмором, стилем и магией. Почему бы тебе просто не загуглить?">
-    
-    <!-- Google Fonts -->
+    <title>SearchForYou — the search portal that does it with style</title>
+    <meta name="description" content="One portal, 25+ search engines — from Google to indie old-web gems like Marginalia & Wiby. Pick an engine, search with cinematic flair, and share links that play an epic search animation.">
+    <meta name="theme-color" content="#0a0a12">
+    <meta name="color-scheme" content="dark light">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="SearchForYou — the search portal that does it with style">
+    <meta property="og:description" content="25+ search engines in one beautiful portal. Mainstream, privacy, AI, academic and indie old-web search — with cinematic animations and shareable links.">
+    <meta name="twitter:card" content="summary_large_image">
+
+    <!-- Preconnect -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    
+    <link rel="preconnect" href="https://cdn.simpleicons.org">
+    <link rel="preconnect" href="https://unpkg.com">
+
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700;800&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+
     <!-- Styles -->
     <link rel="stylesheet" href="styles.css">
-    
-    <!-- Favicon -->
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🔍</text></svg>">
+
+    <!-- Manifest & Favicon -->
+    <link rel="manifest" href="manifest.json">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><defs><linearGradient id='g' x1='0' y1='0' x2='1' y2='1'><stop offset='0' stop-color='%236366f1'/><stop offset='0.5' stop-color='%23a855f7'/><stop offset='1' stop-color='%2322d3ee'/></linearGradient></defs><circle cx='42' cy='42' r='26' fill='none' stroke='url(%23g)' stroke-width='8'/><line x1='62' y1='62' x2='84' y2='84' stroke='url(%23g)' stroke-width='10' stroke-linecap='round'/></svg>">
 </head>
-<body>
-    <!-- Loading Screen for Animations -->
-    <div id="loading-screen" class="loading-screen hidden">
+<body data-theme="dark">
+    <!-- Animated network background -->
+    <canvas id="bg-canvas" aria-hidden="true"></canvas>
+    <div class="aurora" aria-hidden="true">
+        <span class="aurora-blob blob-1"></span>
+        <span class="aurora-blob blob-2"></span>
+        <span class="aurora-blob blob-3"></span>
+    </div>
+    <div class="grain" aria-hidden="true"></div>
+
+    <!-- Loading overlay (shown for shared links) -->
+    <div id="loading-screen" class="overlay loading-screen hidden" aria-hidden="true">
         <div class="loading-content">
             <div class="search-animation">
-                <div class="radar"></div>
-                <div class="scanning-line"></div>
+                <div class="radar">
+                    <span class="radar-sweep"></span>
+                    <span class="radar-dot dot-1"></span>
+                    <span class="radar-dot dot-2"></span>
+                    <span class="radar-dot dot-3"></span>
+                </div>
             </div>
-            <h2 id="loading-text">Поиск ответа...</h2>
-            <div class="progress-bar">
-                <div class="progress-fill"></div>
-            </div>
+            <h2 id="loading-text">Searching…</h2>
+            <p id="loading-query" class="loading-query"></p>
+            <div class="progress-bar"><div class="progress-fill"></div></div>
         </div>
     </div>
 
-    <!-- Success Screen -->
-    <div id="success-screen" class="success-screen hidden">
+    <!-- Success overlay -->
+    <div id="success-screen" class="overlay success-screen hidden" aria-hidden="true">
         <div class="success-content">
-            <div class="success-icon">✅</div>
-            <h1>ОТВЕТ НАЙДЕН!</h1>
-            <p>Перенаправление...</p>
+            <div class="success-icon"><i data-lucide="check-circle-2"></i></div>
+            <h1 data-i18n="success.title">ANSWER FOUND!</h1>
+            <p data-i18n="success.subtitle">Redirecting you now…</p>
         </div>
     </div>
 
-    <!-- Main Application -->
+    <!-- Top bar -->
+    <nav class="topbar">
+        <a class="brand" href="./" aria-label="SearchForYou home">
+            <span class="brand-mark"><i data-lucide="search"></i></span>
+            <span class="brand-name">Search<span class="brand-accent">For</span>You</span>
+        </a>
+        <div class="controls">
+            <button id="lang-toggle" class="ctrl-btn" type="button" aria-label="Switch language" title="Switch language">
+                <i data-lucide="languages"></i>
+                <span id="lang-label" class="ctrl-label">EN</span>
+            </button>
+            <button id="theme-toggle" class="ctrl-btn" type="button" aria-label="Toggle theme" title="Toggle theme">
+                <i data-lucide="moon" class="icon-dark"></i>
+                <i data-lucide="sun" class="icon-light"></i>
+            </button>
+            <a class="ctrl-btn" href="https://github.com/Vadim-Khristenko/Search-for-YOU" target="_blank" rel="noopener" aria-label="GitHub repository" title="Star on GitHub">
+                <i data-lucide="github"></i>
+            </a>
+        </div>
+    </nav>
+
+    <!-- Main app -->
     <main class="app">
-        <header class="header">
-            <h1 class="logo">
-                <span class="logo-icon">🔍</span>
-                SearchForYou
+        <header class="hero">
+            <div class="hero-badge">
+                <span class="pulse-dot"></span>
+                <span data-i18n="hero.badge">25+ search engines · one portal</span>
+            </div>
+            <h1 class="hero-title">
+                <span data-i18n="hero.titleA">Search</span><span class="grad-text" data-i18n="hero.titleB">ForYou</span>
             </h1>
-            <p class="tagline">потому что вы способны найти это сами</p>
+            <p class="hero-tagline" data-i18n="hero.tagline">Because you can find it yourself — but we make it cinematic.</p>
+            <p class="hero-sub" id="hero-rotator" data-i18n="hero.sub">Mainstream, privacy, AI, academic &amp; indie old-web search in one place.</p>
         </header>
 
-        <div class="search-container">
-            <form id="search-form" class="search-form">
+        <section class="search-card glass">
+            <form id="search-form" class="search-form" autocomplete="off">
                 <div class="input-group">
-                    <input 
-                        type="text" 
-                        id="query-input" 
-                        class="query-input" 
-                        placeholder="Введите ваш вопрос…" 
+                    <i data-lucide="search" class="input-icon"></i>
+                    <input
+                        type="text"
+                        id="query-input"
+                        class="query-input"
+                        placeholder="Type anything…"
+                        data-i18n-placeholder="search.placeholder"
                         autocomplete="off"
                         required
                     >
-                    <div class="typing-cursor"></div>
+                    <button type="button" id="clear-btn" class="clear-btn hidden" aria-label="Clear">
+                        <i data-lucide="x"></i>
+                    </button>
+                    <span class="typing-cursor"></span>
                 </div>
 
-                <div class="search-engines">
-                    <h3>Выберите поисковую систему:</h3>
-                    <div class="engine-buttons">
-                        <button type="button" class="engine-btn active" data-engine="google">
-                            <svg class="engine-icon" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-                                <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-                                <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-                                <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-                            </svg>
-                            Google
-                        </button>
-                        
-                        <button type="button" class="engine-btn" data-engine="yandex">
-                            <svg class="engine-icon" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.94-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v-.07zM17.9 17.39c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z"/>
-                            </svg>
-                            Yandex
-                        </button>
-                        
-                        <button type="button" class="engine-btn" data-engine="bing">
-                            <svg class="engine-icon" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M5.71 3L3 4.35v11.43L12 21l9-5.22V9.65L5.71 3zM12 16.47L6 13.74V8.26l6 2.73v5.48z"/>
-                            </svg>
-                            Bing
-                        </button>
-                        
-                        <button type="button" class="engine-btn" data-engine="duckduckgo">
-                            <svg class="engine-icon" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 3c1.66 0 3 1.34 3 3s-1.34 3-3 3-3-1.34-3-3 1.34-3 3-3zm0 14.2c-2.5 0-4.71-1.28-6-3.22.03-1.99 4-3.08 6-3.08 1.99 0 5.97 1.09 6 3.08-1.29 1.94-3.5 3.22-6 3.22z"/>
-                            </svg>
-                            DuckDuckGo
-                        </button>
-                    </div>
+                <div class="engines-head">
+                    <h3 data-i18n="engines.heading">Choose your engine</h3>
+                    <button type="button" id="surprise-btn" class="surprise-btn" title="Pick a random engine">
+                        <i data-lucide="dices"></i>
+                        <span data-i18n="engines.surprise">Surprise me</span>
+                    </button>
                 </div>
 
-                <div class="custom-url-section">
-                    <details class="custom-url-details">
-                        <summary>Или укажите свою ссылку (Custom URL)</summary>
-                        <input 
-                            type="url" 
-                            id="custom-url" 
-                            class="custom-url-input" 
-                            placeholder="https://example.com/your-answer"
-                        >
-                    </details>
-                </div>
+                <div class="category-tabs" id="category-tabs" role="tablist"></div>
+
+                <div class="engine-grid" id="engine-grid"></div>
+
+                <details class="custom-url-details">
+                    <summary>
+                        <i data-lucide="link"></i>
+                        <span data-i18n="custom.summary">Or point to a custom URL</span>
+                    </summary>
+                    <input
+                        type="url"
+                        id="custom-url"
+                        class="custom-url-input"
+                        placeholder="https://example.com/your-answer"
+                    >
+                </details>
 
                 <div class="action-buttons">
                     <button type="submit" class="search-btn primary">
-                        <span class="btn-text">Найти ответ</span>
-                        <span class="btn-icon">🔍</span>
+                        <i data-lucide="rocket"></i>
+                        <span data-i18n="actions.search">Find the answer</span>
                     </button>
-                    
                     <button type="button" id="share-btn" class="search-btn secondary">
-                        <span class="btn-text">Поделиться запросом</span>
-                        <span class="btn-icon">🔗</span>
+                        <i data-lucide="share-2"></i>
+                        <span data-i18n="actions.share">Share query</span>
                     </button>
                 </div>
             </form>
 
-            <!-- Share URL Display -->
             <div id="share-result" class="share-result hidden">
-                <h3>Ссылка для поделиться:</h3>
+                <h3 data-i18n="share.heading">Your shareable link</h3>
                 <div class="share-url-container">
                     <input type="text" id="share-url" class="share-url-input" readonly>
                     <button id="copy-btn" class="copy-btn">
-                        <span class="copy-text">Копировать</span>
-                        <span class="copy-icon">📋</span>
+                        <i data-lucide="copy"></i>
+                        <span class="copy-text" data-i18n="share.copy">Copy</span>
                     </button>
                 </div>
-                <p class="share-description">
-                    Отправьте эту ссылку — получатель увидит эпическую анимацию поиска!
+                <p class="share-description" data-i18n="share.description">
+                    Send it to anyone — they'll get the full cinematic search animation before landing on the results.
                 </p>
             </div>
-        </div>
+        </section>
+
+        <section class="features">
+            <article class="feature-card glass">
+                <span class="feature-ico"><i data-lucide="shield-check"></i></span>
+                <h4 data-i18n="feat.privacy.t">Privacy first</h4>
+                <p data-i18n="feat.privacy.d">No tracking, no cookies, no backend. Pure static, runs entirely in your browser.</p>
+            </article>
+            <article class="feature-card glass">
+                <span class="feature-ico"><i data-lucide="sparkles"></i></span>
+                <h4 data-i18n="feat.engines.t">25+ engines</h4>
+                <p data-i18n="feat.engines.d">Mainstream, privacy, AI, academic and indie old-web search — all curated for you.</p>
+            </article>
+            <article class="feature-card glass">
+                <span class="feature-ico"><i data-lucide="wand-2"></i></span>
+                <h4 data-i18n="feat.fun.t">Cinematic links</h4>
+                <p data-i18n="feat.fun.d">Reply to "just google it" with a link that plays an epic search sequence.</p>
+            </article>
+        </section>
 
         <footer class="footer">
-            <p>SearchForYou — потому что вы способны найти это сами. Но мы поможем с эффектами.</p>
+            <p data-i18n="footer.text">SearchForYou — because you can find it yourself. We just make it look incredible.</p>
+            <p class="footer-sub">
+                <a href="https://github.com/Vadim-Khristenko/Search-for-YOU" target="_blank" rel="noopener">GitHub</a>
+                · <span data-i18n="footer.made">Crafted with</span> <i data-lucide="heart" class="heart"></i>
+            </p>
         </footer>
     </main>
 
-    <!-- Scripts -->
+    <!-- Toast -->
+    <div id="toast" class="toast hidden" role="status" aria-live="polite"></div>
+
+    <!-- Icon library -->
+    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.min.js"></script>
+    <!-- App -->
+    <script src="i18n.js"></script>
+    <script src="engines.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "SearchForYou",
+  "short_name": "SearchForYou",
+  "description": "25+ search engines in one beautiful portal — mainstream, privacy, AI, academic and indie old-web search, with cinematic animations and shareable links.",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#07070d",
+  "theme_color": "#07070d",
+  "icons": [
+    {
+      "src": "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><defs><linearGradient id='g' x1='0' y1='0' x2='1' y2='1'><stop offset='0' stop-color='%236366f1'/><stop offset='0.5' stop-color='%23a855f7'/><stop offset='1' stop-color='%2322d3ee'/></linearGradient></defs><rect width='100' height='100' rx='22' fill='%2307070d'/><circle cx='42' cy='42' r='22' fill='none' stroke='url(%23g)' stroke-width='7'/><line x1='59' y1='59' x2='80' y2='80' stroke='url(%23g)' stroke-width='9' stroke-linecap='round'/></svg>",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/script.js
+++ b/script.js
@@ -1,384 +1,452 @@
-// Search engine configurations
-const SEARCH_ENGINES = {
-    google: {
-        name: 'Google',
-        url: 'https://www.google.com/search?q=',
-        encode: true
-    },
-    yandex: {
-        name: 'Yandex',
-        url: 'https://yandex.ru/search/?text=',
-        encode: true
-    },
-    bing: {
-        name: 'Bing',
-        url: 'https://www.bing.com/search?q=',
-        encode: true
-    },
-    duckduckgo: {
-        name: 'DuckDuckGo',
-        url: 'https://duckduckgo.com/?q=',
-        encode: true
-    }
-};
+/* ============================================================
+   SearchForYou — application logic
+   Vanilla JS, no build step. Depends on i18n.js & engines.js.
+   ============================================================ */
 
-// Animation states
-const LOADING_MESSAGES = [
-    'Поиск ответа...',
-    'Сканирую интернет...',
-    'Анализирую данные...',
-    'Обрабатываю результаты...',
-    'Обнаружено совпадение!'
-];
+(() => {
+    'use strict';
 
-class SearchForYou {
-    constructor() {
-        this.currentEngine = 'google';
-        this.isAnimating = false;
-        
-        this.initializeElements();
-        this.bindEvents();
-        this.checkUrlParameters();
-    }
+    const LS_THEME = 'sfy-theme';
+    const LS_LANG  = 'sfy-lang';
+    const LS_ENGINE = 'sfy-engine';
 
-    initializeElements() {
-        // Form elements
-        this.searchForm = document.getElementById('search-form');
-        this.queryInput = document.getElementById('query-input');
-        this.customUrlInput = document.getElementById('custom-url');
-        this.engineButtons = document.querySelectorAll('.engine-btn');
-        this.shareBtn = document.getElementById('share-btn');
-        this.copyBtn = document.getElementById('copy-btn');
-        
-        // Display elements
-        this.shareResult = document.getElementById('share-result');
-        this.shareUrl = document.getElementById('share-url');
-        this.loadingScreen = document.getElementById('loading-screen');
-        this.successScreen = document.getElementById('success-screen');
-        this.loadingText = document.getElementById('loading-text');
-        this.typingCursor = document.querySelector('.typing-cursor');
-    }
+    /* ---------- tiny helpers ---------- */
+    const $  = (sel, root = document) => root.querySelector(sel);
+    const $$ = (sel, root = document) => [...root.querySelectorAll(sel)];
+    const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+    const prefersReduced = () => window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const refreshIcons = () => { if (window.lucide) window.lucide.createIcons(); };
 
-    bindEvents() {
-        // Form submission
-        this.searchForm.addEventListener('submit', (e) => this.handleSearch(e));
-        
-        // Engine selection
-        this.engineButtons.forEach(btn => {
-            btn.addEventListener('click', (e) => this.selectEngine(e));
-        });
-        
-        // Share functionality
-        this.shareBtn.addEventListener('click', () => this.generateShareUrl());
-        this.copyBtn.addEventListener('click', () => this.copyToClipboard());
-        
-        // Input events
-        this.queryInput.addEventListener('input', () => this.hideShareResult());
-        this.customUrlInput.addEventListener('input', () => this.hideShareResult());
-    }
+    /* ============================================================
+       i18n
+       ============================================================ */
+    const I18N = window.I18N;
+    const savedLang = localStorage.getItem(LS_LANG);
+    let lang = savedLang || ((navigator.language || '').toLowerCase().startsWith('ru') ? 'ru' : 'en');
+    if (!I18N[lang]) lang = 'en';
 
-    checkUrlParameters() {
-        const urlParams = new URLSearchParams(window.location.search);
-        const query = urlParams.get('q');
-        const engine = urlParams.get('engine');
-        const customUrl = urlParams.get('custom');
+    const t = (key) => (I18N[lang] && I18N[lang][key]) || (I18N.en[key]) || key;
 
-        if (query) {
-            // This is a shared link - start the animation sequence
-            this.startSharedLinkAnimation(query, engine, customUrl);
-        }
-    }
-
-    async startSharedLinkAnimation(query, engine, customUrl) {
-        if (this.isAnimating) return;
-        this.isAnimating = true;
-
-        // Set the query in the input
-        this.queryInput.value = '';
-        
-        // Set the engine if provided
-        if (engine && SEARCH_ENGINES[engine]) {
-            this.selectEngineByName(engine);
-        }
-
-        // Start typing animation
-        await this.typeText(query);
-        
-        // Start search animation
-        await this.playSearchAnimation();
-        
-        // Show success screen
-        await this.showSuccessScreen();
-        
-        // Redirect to search results or custom URL
-        this.redirectToResults(query, engine, customUrl);
-    }
-
-    async typeText(text) {
-        this.typingCursor.classList.add('active');
-        
-        for (let i = 0; i <= text.length; i++) {
-            this.queryInput.value = text.substring(0, i);
-            await this.delay(100 + Math.random() * 100); // Variable typing speed
-        }
-        
-        this.typingCursor.classList.remove('active');
-        await this.delay(500);
-    }
-
-    async playSearchAnimation() {
-        this.loadingScreen.classList.remove('hidden');
-        
-        for (let i = 0; i < LOADING_MESSAGES.length; i++) {
-            this.loadingText.textContent = LOADING_MESSAGES[i];
-            await this.delay(800 + Math.random() * 400);
-        }
-    }
-
-    async showSuccessScreen() {
-        this.loadingScreen.classList.add('hidden');
-        this.successScreen.classList.remove('hidden');
-        await this.delay(1500);
-    }
-
-    redirectToResults(query, engine, customUrl) {
-        if (customUrl) {
-            window.location.href = customUrl;
-        } else {
-            const searchEngine = SEARCH_ENGINES[engine] || SEARCH_ENGINES[this.currentEngine];
-            const searchUrl = searchEngine.url + (searchEngine.encode ? encodeURIComponent(query) : query);
-            window.location.href = searchUrl;
-        }
-    }
-
-    handleSearch(e) {
-        e.preventDefault();
-        
-        const query = this.queryInput.value.trim();
-        const customUrl = this.customUrlInput.value.trim();
-        
-        if (!query) {
-            this.queryInput.focus();
-            return;
-        }
-
-        if (customUrl) {
-            // Direct redirect to custom URL
-            window.location.href = customUrl;
-        } else {
-            // Redirect to search engine
-            const searchEngine = SEARCH_ENGINES[this.currentEngine];
-            const searchUrl = searchEngine.url + encodeURIComponent(query);
-            window.location.href = searchUrl;
-        }
-    }
-
-    selectEngine(e) {
-        // Remove active class from all buttons
-        this.engineButtons.forEach(btn => btn.classList.remove('active'));
-        
-        // Add active class to clicked button
-        e.target.classList.add('active');
-        
-        // Set current engine
-        this.currentEngine = e.target.dataset.engine;
-        
-        // Hide share result if visible
-        this.hideShareResult();
-    }
-
-    selectEngineByName(engineName) {
-        this.currentEngine = engineName;
-        
-        // Update UI
-        this.engineButtons.forEach(btn => {
-            btn.classList.remove('active');
-            if (btn.dataset.engine === engineName) {
-                btn.classList.add('active');
-            }
+    function applyLang() {
+        document.documentElement.lang = lang;
+        $$('[data-i18n]').forEach((el) => { el.textContent = t(el.dataset.i18n); });
+        $$('[data-i18n-placeholder]').forEach((el) => { el.placeholder = t(el.dataset.i18nPlaceholder); });
+        const label = $('#lang-label');
+        if (label) label.textContent = t('lang.name');
+        // re-render category tab labels
+        $$('.cat-tab').forEach((tab) => {
+            const span = $('.cat-label', tab);
+            if (span) span.textContent = t('cat.' + tab.dataset.cat);
         });
     }
 
-    generateShareUrl() {
-        const query = this.queryInput.value.trim();
-        const customUrl = this.customUrlInput.value.trim();
-        
-        if (!query) {
-            this.queryInput.focus();
-            return;
-        }
+    function toggleLang() {
+        lang = lang === 'en' ? 'ru' : 'en';
+        localStorage.setItem(LS_LANG, lang);
+        applyLang();
+    }
 
-        // Build URL parameters
+    /* ============================================================
+       Theme
+       ============================================================ */
+    function getInitialTheme() {
+        const saved = localStorage.getItem(LS_THEME);
+        if (saved) return saved;
+        return 'dark'; // dark by default, per design
+    }
+    let theme = getInitialTheme();
+
+    function applyTheme() {
+        document.documentElement.setAttribute('data-theme', theme);
+        document.body.setAttribute('data-theme', theme);
+        const meta = $('meta[name="theme-color"]');
+        if (meta) meta.setAttribute('content', theme === 'dark' ? '#07070d' : '#f4f5fb');
+    }
+
+    function toggleTheme() {
+        theme = theme === 'dark' ? 'light' : 'dark';
+        localStorage.setItem(LS_THEME, theme);
+        applyTheme();
+    }
+
+    /* ============================================================
+       Toast
+       ============================================================ */
+    let toastTimer;
+    function toast(msg) {
+        const el = $('#toast');
+        if (!el) return;
+        el.textContent = msg;
+        el.classList.remove('hidden');
+        requestAnimationFrame(() => el.classList.add('show'));
+        clearTimeout(toastTimer);
+        toastTimer = setTimeout(() => {
+            el.classList.remove('show');
+            setTimeout(() => el.classList.add('hidden'), 400);
+        }, 2600);
+    }
+
+    /* ============================================================
+       Engine + category rendering
+       ============================================================ */
+    const ENGINES = window.SEARCH_ENGINES;
+    const ENGINE_MAP = window.ENGINE_MAP;
+    const CATEGORIES = window.CATEGORIES;
+
+    let currentEngine = localStorage.getItem(LS_ENGINE) || 'google';
+    if (!ENGINE_MAP[currentEngine]) currentEngine = 'google';
+    let activeCat = 'all';
+
+    function engineBadge(engine) {
+        const color = encodeURIComponent(engine.color.replace('#', ''));
+        if (engine.icon) {
+            const src = `https://cdn.simpleicons.org/${engine.icon}/${color}`;
+            return `<span class="engine-badge"><img src="${src}" alt="" loading="lazy"
+                onerror="this.replaceWith(Object.assign(document.createElement('span'),{className:'monogram',textContent:'${engine.name[0]}'}))"></span>`;
+        }
+        return `<span class="engine-badge"><span class="monogram">${engine.name[0]}</span></span>`;
+    }
+
+    function renderCategories() {
+        const wrap = $('#category-tabs');
+        wrap.innerHTML = CATEGORIES.map((c) => `
+            <button type="button" class="cat-tab${c.id === activeCat ? ' active' : ''}" data-cat="${c.id}" role="tab">
+                <i data-lucide="${c.icon}"></i>
+                <span class="cat-label">${t('cat.' + c.id)}</span>
+            </button>`).join('');
+        $$('.cat-tab', wrap).forEach((tab) => {
+            tab.addEventListener('click', () => {
+                activeCat = tab.dataset.cat;
+                $$('.cat-tab').forEach((t2) => t2.classList.toggle('active', t2 === tab));
+                renderEngines();
+            });
+        });
+        refreshIcons();
+    }
+
+    function renderEngines() {
+        const grid = $('#engine-grid');
+        const list = activeCat === 'all' ? ENGINES : ENGINES.filter((e) => e.cat === activeCat);
+        grid.innerHTML = list.map((e, i) => `
+            <button type="button" class="engine-btn${e.id === currentEngine ? ' active' : ''}"
+                    data-engine="${e.id}" style="--c:${e.color}; animation-delay:${i * 22}ms"
+                    title="${e.name}">
+                ${engineBadge(e)}
+                <span class="engine-name">${e.name}</span>
+            </button>`).join('');
+        $$('.engine-btn', grid).forEach((btn) => {
+            btn.addEventListener('click', () => selectEngine(btn.dataset.engine));
+        });
+        refreshIcons();
+    }
+
+    function selectEngine(id, { silent = false } = {}) {
+        if (!ENGINE_MAP[id]) return;
+        currentEngine = id;
+        localStorage.setItem(LS_ENGINE, id);
+        $$('.engine-btn').forEach((b) => b.classList.toggle('active', b.dataset.engine === id));
+        hideShareResult();
+        if (!silent && !$('.engine-btn[data-engine="' + id + '"]')) {
+            // engine not visible in current category — jump to "all"
+            activeCat = 'all';
+            $$('.cat-tab').forEach((tb) => tb.classList.toggle('active', tb.dataset.cat === 'all'));
+            renderEngines();
+        }
+    }
+
+    function surprise() {
+        const pick = ENGINES[Math.floor(Math.random() * ENGINES.length)];
+        activeCat = 'all';
+        $$('.cat-tab').forEach((tb) => tb.classList.toggle('active', tb.dataset.cat === 'all'));
+        currentEngine = pick.id;
+        localStorage.setItem(LS_ENGINE, pick.id);
+        renderEngines();
+        const btn = $('.engine-btn[data-engine="' + pick.id + '"]');
+        if (btn) btn.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        toast(`${t('toast.surprise')} ${pick.name}`);
+    }
+
+    /* ============================================================
+       Search + share
+       ============================================================ */
+    const queryInput = $('#query-input');
+    const customUrlInput = $('#custom-url');
+
+    function buildSearchUrl(query, engineId, customUrl) {
+        if (customUrl) return customUrl;
+        const engine = ENGINE_MAP[engineId] || ENGINE_MAP[currentEngine];
+        return engine.url + (engine.encode ? encodeURIComponent(query) : query);
+    }
+
+    function doSearch(e) {
+        if (e) e.preventDefault();
+        const query = queryInput.value.trim();
+        const customUrl = customUrlInput.value.trim();
+        if (!query && !customUrl) { toast(t('toast.needQuery')); queryInput.focus(); return; }
+        window.location.href = buildSearchUrl(query, currentEngine, customUrl);
+    }
+
+    function generateShareUrl() {
+        const query = queryInput.value.trim();
+        const customUrl = customUrlInput.value.trim();
+        if (!query) { toast(t('toast.needQuery')); queryInput.focus(); return; }
+
         const params = new URLSearchParams();
         params.set('q', query);
-        params.set('engine', this.currentEngine);
-        
-        if (customUrl) {
-            params.set('custom', customUrl);
-        }
+        params.set('engine', currentEngine);
+        if (customUrl) params.set('custom', customUrl);
 
-        // Generate the share URL
-        const baseUrl = window.location.origin + window.location.pathname;
-        const shareUrl = `${baseUrl}?${params.toString()}`;
-        
-        // Display the share URL
-        this.shareUrl.value = shareUrl;
-        this.shareResult.classList.remove('hidden');
-        this.shareResult.classList.add('fade-in');
-        
-        // Scroll to share result
-        this.shareResult.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        const base = window.location.origin + window.location.pathname;
+        const shareUrl = `${base}?${params.toString()}`;
+
+        $('#share-url').value = shareUrl;
+        const box = $('#share-result');
+        box.classList.remove('hidden');
+        box.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+        // try native share on supported devices
+        if (navigator.share && /Mobi|Android/i.test(navigator.userAgent)) {
+            navigator.share({ title: 'SearchForYou', text: query, url: shareUrl }).catch(() => {});
+        }
     }
 
-    async copyToClipboard() {
+    function hideShareResult() {
+        const box = $('#share-result');
+        if (box) box.classList.add('hidden');
+    }
+
+    async function copyShareUrl() {
+        const input = $('#share-url');
+        const btn = $('#copy-btn');
+        const label = $('.copy-text', btn);
+        const original = label.textContent;
         try {
-            await navigator.clipboard.writeText(this.shareUrl.value);
-            
-            // Visual feedback
-            const originalText = this.copyBtn.querySelector('.copy-text').textContent;
-            this.copyBtn.querySelector('.copy-text').textContent = 'Скопировано!';
-            this.copyBtn.classList.add('copied');
-            
-            setTimeout(() => {
-                this.copyBtn.querySelector('.copy-text').textContent = originalText;
-                this.copyBtn.classList.remove('copied');
-            }, 2000);
-            
-        } catch (err) {
-            // Fallback for older browsers
-            this.shareUrl.select();
-            document.execCommand('copy');
-            
-            // Visual feedback
-            const originalText = this.copyBtn.querySelector('.copy-text').textContent;
-            this.copyBtn.querySelector('.copy-text').textContent = 'Скопировано!';
-            this.copyBtn.classList.add('copied');
-            
-            setTimeout(() => {
-                this.copyBtn.querySelector('.copy-text').textContent = originalText;
-                this.copyBtn.classList.remove('copied');
-            }, 2000);
+            await navigator.clipboard.writeText(input.value);
+        } catch {
+            input.select();
+            try { document.execCommand('copy'); } catch { toast(t('toast.copyFail')); return; }
+        }
+        label.textContent = t('share.copied');
+        btn.classList.add('copied');
+        toast(t('toast.copied'));
+        setTimeout(() => { label.textContent = original; btn.classList.remove('copied'); }, 2000);
+    }
+
+    /* ============================================================
+       Shared-link cinematic sequence
+       ============================================================ */
+    let isAnimating = false;
+
+    async function typeText(text) {
+        const cursor = $('.typing-cursor');
+        cursor.classList.add('active');
+        queryInput.value = '';
+        for (let i = 0; i <= text.length; i++) {
+            queryInput.value = text.slice(0, i);
+            await delay(55 + Math.random() * 70);
+        }
+        cursor.classList.remove('active');
+        await delay(400);
+    }
+
+    async function playLoading(query) {
+        const screen = $('#loading-screen');
+        const textEl = $('#loading-text');
+        const queryEl = $('#loading-query');
+        screen.classList.remove('hidden');
+        queryEl.textContent = `"${query}"`;
+        for (let i = 0; i < 5; i++) {
+            textEl.textContent = t('loading.' + i);
+            await delay(720 + Math.random() * 320);
         }
     }
 
-    hideShareResult() {
-        this.shareResult.classList.add('hidden');
+    async function showSuccess() {
+        $('#loading-screen').classList.add('hidden');
+        const s = $('#success-screen');
+        s.classList.remove('hidden');
+        refreshIcons();
+        await delay(1500);
     }
 
-    delay(ms) {
-        return new Promise(resolve => setTimeout(resolve, ms));
-    }
-}
+    async function runSharedAnimation(query, engineId, customUrl) {
+        if (isAnimating) return;
+        isAnimating = true;
+        if (engineId && ENGINE_MAP[engineId]) selectEngine(engineId, { silent: true });
 
-// Enhanced animations with performance optimization
-class AnimationHelper {
-    static addScrollAnimations() {
-        const observerOptions = {
-            threshold: 0.1,
-            rootMargin: '0px 0px -50px 0px'
+        const target = buildSearchUrl(query, engineId, customUrl);
+
+        if (prefersReduced()) { window.location.href = target; return; }
+
+        await typeText(query);
+        await playLoading(query);
+        await showSuccess();
+        window.location.href = target;
+    }
+
+    function checkUrlParams() {
+        const p = new URLSearchParams(window.location.search);
+        const query = p.get('q');
+        if (!query) return false;
+        runSharedAnimation(query, p.get('engine'), p.get('custom'));
+        return true;
+    }
+
+    /* ============================================================
+       Animated network background (canvas)
+       ============================================================ */
+    function initCanvas() {
+        if (prefersReduced()) return;
+        const canvas = $('#bg-canvas');
+        const ctx = canvas.getContext('2d');
+        let w, h, dpr, nodes = [], raf;
+
+        const cssVar = (name) => getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+
+        function resize() {
+            dpr = Math.min(window.devicePixelRatio || 1, 2);
+            w = canvas.width = innerWidth * dpr;
+            h = canvas.height = innerHeight * dpr;
+            canvas.style.width = innerWidth + 'px';
+            canvas.style.height = innerHeight + 'px';
+            const count = Math.min(80, Math.floor((innerWidth * innerHeight) / 22000));
+            nodes = Array.from({ length: count }, () => ({
+                x: Math.random() * w, y: Math.random() * h,
+                vx: (Math.random() - 0.5) * 0.25 * dpr,
+                vy: (Math.random() - 0.5) * 0.25 * dpr,
+                r: (Math.random() * 1.6 + 0.8) * dpr
+            }));
+        }
+
+        const mouse = { x: -9999, y: -9999 };
+        window.addEventListener('mousemove', (e) => { mouse.x = e.clientX * dpr; mouse.y = e.clientY * dpr; });
+        window.addEventListener('mouseout', () => { mouse.x = -9999; mouse.y = -9999; });
+
+        function draw() {
+            ctx.clearRect(0, 0, w, h);
+            const lineColor = cssVar('--canvas-line');
+            const dotColor = cssVar('--canvas-dot');
+            const maxDist = 130 * dpr;
+
+            for (const n of nodes) {
+                n.x += n.vx; n.y += n.vy;
+                if (n.x < 0 || n.x > w) n.vx *= -1;
+                if (n.y < 0 || n.y > h) n.vy *= -1;
+            }
+            // links
+            for (let i = 0; i < nodes.length; i++) {
+                for (let j = i + 1; j < nodes.length; j++) {
+                    const a = nodes[i], b = nodes[j];
+                    const dx = a.x - b.x, dy = a.y - b.y;
+                    const dist = Math.hypot(dx, dy);
+                    if (dist < maxDist) {
+                        ctx.globalAlpha = (1 - dist / maxDist) * 0.55;
+                        ctx.strokeStyle = lineColor;
+                        ctx.lineWidth = 1 * dpr;
+                        ctx.beginPath(); ctx.moveTo(a.x, a.y); ctx.lineTo(b.x, b.y); ctx.stroke();
+                    }
+                }
+            }
+            // mouse links
+            for (const n of nodes) {
+                const dx = n.x - mouse.x, dy = n.y - mouse.y;
+                const dist = Math.hypot(dx, dy);
+                if (dist < maxDist * 1.6) {
+                    ctx.globalAlpha = (1 - dist / (maxDist * 1.6)) * 0.7;
+                    ctx.strokeStyle = dotColor;
+                    ctx.lineWidth = 1 * dpr;
+                    ctx.beginPath(); ctx.moveTo(n.x, n.y); ctx.lineTo(mouse.x, mouse.y); ctx.stroke();
+                }
+            }
+            // dots
+            ctx.globalAlpha = 1;
+            ctx.fillStyle = dotColor;
+            for (const n of nodes) { ctx.beginPath(); ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2); ctx.fill(); }
+
+            raf = requestAnimationFrame(draw);
+        }
+
+        let resizeTimer;
+        window.addEventListener('resize', () => { clearTimeout(resizeTimer); resizeTimer = setTimeout(resize, 200); });
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden) cancelAnimationFrame(raf);
+            else draw();
+        });
+
+        resize();
+        draw();
+    }
+
+    /* ============================================================
+       Hero rotator (subtle cycling subtitle)
+       ============================================================ */
+    function initRotator() {
+        const phrases = {
+            en: ['Mainstream, privacy, AI, academic & indie old-web search in one place.',
+                 'Tired of "just google it"? Send a link that searches with style.',
+                 'Discover engines you never knew existed — Marginalia, Wiby, Stract & more.'],
+            ru: ['Массовые, приватные, ИИ, академические и инди-поисковики — в одном месте.',
+                 'Устали от «да загугли сам»? Отправьте ссылку, что ищет со стилем.',
+                 'Откройте поисковики, о которых не знали — Marginalia, Wiby, Stract и другие.']
         };
+        const el = $('#hero-rotator');
+        if (!el || prefersReduced()) return;
+        let i = 0;
+        setInterval(() => {
+            const arr = phrases[lang] || phrases.en;
+            i = (i + 1) % arr.length;
+            el.style.opacity = '0';
+            setTimeout(() => { el.textContent = arr[i]; el.style.opacity = '1'; }, 350);
+        }, 5200);
+        el.style.transition = 'opacity 0.35s ease';
+    }
 
-        const observer = new IntersectionObserver((entries) => {
-            entries.forEach(entry => {
-                if (entry.isIntersecting) {
-                    entry.target.classList.add('fade-in');
-                }
-            });
-        }, observerOptions);
+    /* ============================================================
+       Wire up events + init
+       ============================================================ */
+    function init() {
+        applyTheme();
+        applyLang();
+        renderCategories();
+        renderEngines();
+        refreshIcons();
 
-        // Observe elements that should animate on scroll
-        document.querySelectorAll('.search-container, .footer').forEach(el => {
-            observer.observe(el);
+        $('#theme-toggle').addEventListener('click', toggleTheme);
+        $('#lang-toggle').addEventListener('click', () => { toggleLang(); renderCategories(); renderEngines(); });
+        $('#surprise-btn').addEventListener('click', surprise);
+        $('#search-form').addEventListener('submit', doSearch);
+        $('#share-btn').addEventListener('click', generateShareUrl);
+        $('#copy-btn').addEventListener('click', copyShareUrl);
+
+        const clearBtn = $('#clear-btn');
+        queryInput.addEventListener('input', () => {
+            clearBtn.classList.toggle('hidden', !queryInput.value);
+            hideShareResult();
         });
-    }
-
-    static addHoverEffects() {
-        // Add subtle hover effects to interactive elements
-        const buttons = document.querySelectorAll('button, .engine-btn');
-        
-        buttons.forEach(button => {
-            button.addEventListener('mouseenter', () => {
-                button.style.transform = 'translateY(-2px)';
-            });
-            
-            button.addEventListener('mouseleave', () => {
-                button.style.transform = 'translateY(0)';
-            });
+        clearBtn.addEventListener('click', () => {
+            queryInput.value = '';
+            clearBtn.classList.add('hidden');
+            queryInput.focus();
         });
-    }
+        customUrlInput.addEventListener('input', hideShareResult);
 
-    static optimizeAnimations() {
-        // Reduce animations for users who prefer reduced motion
-        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-            document.body.classList.add('reduce-motion');
-            
-            // Add CSS to disable animations
-            const style = document.createElement('style');
-            style.textContent = `
-                .reduce-motion *,
-                .reduce-motion *::before,
-                .reduce-motion *::after {
-                    animation-duration: 0.01ms !important;
-                    animation-iteration-count: 1 !important;
-                    transition-duration: 0.01ms !important;
-                }
-            `;
-            document.head.appendChild(style);
-        }
-    }
-}
-
-// Performance monitoring
-class PerformanceMonitor {
-    static init() {
-        // Monitor page load performance
-        window.addEventListener('load', () => {
-            const perfData = performance.getEntriesByType('navigation')[0];
-            console.log('Page load time:', perfData.loadEventEnd - perfData.loadEventStart, 'ms');
-            
-            // Check bundle size
-            this.checkBundleSize();
-        });
-    }
-
-    static checkBundleSize() {
-        const resources = performance.getEntriesByType('resource');
-        let totalSize = 0;
-        
-        resources.forEach(resource => {
-            if (resource.transferSize) {
-                totalSize += resource.transferSize;
+        // keyboard: "/" focuses the search box
+        document.addEventListener('keydown', (e) => {
+            if (e.key === '/' && document.activeElement !== queryInput && document.activeElement !== customUrlInput) {
+                e.preventDefault(); queryInput.focus();
             }
         });
-        
-        console.log('Total resources size:', (totalSize / 1024).toFixed(2), 'KB');
-        
-        if (totalSize > 512 * 1024) { // 512KB limit
-            console.warn('Bundle size exceeds 512KB target');
-        }
+
+        initCanvas();
+        initRotator();
+
+        // shared-link sequence takes over if ?q= present
+        checkUrlParams();
     }
-}
 
-// Initialize the application
-document.addEventListener('DOMContentLoaded', () => {
-    // Initialize main application
-    new SearchForYou();
-    
-    // Initialize animation helpers
-    AnimationHelper.addScrollAnimations();
-    AnimationHelper.addHoverEffects();
-    AnimationHelper.optimizeAnimations();
-    
-    // Initialize performance monitoring
-    PerformanceMonitor.init();
-    
-    console.log('SearchForYou initialized successfully! 🔍');
-});
-
-// Service Worker registration for better performance (optional)
-if ('serviceWorker' in navigator) {
-    window.addEventListener('load', () => {
-        // We could register a service worker here for caching
-        // navigator.serviceWorker.register('/sw.js');
-    });
-}
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,672 +1,472 @@
-/* CSS Custom Properties */
+/* ============================================================
+   SearchForYou — stylesheet
+   Dark theme by default, light theme via [data-theme="light"].
+   ============================================================ */
+
+/* ---------- Design tokens ---------- */
 :root {
-    --primary-color: #0070f3;
-    --primary-hover: #0060df;
-    --secondary-color: #6b7280;
-    --success-color: #10b981;
-    --background: #ffffff;
-    --surface: #f8fafc;
-    --border: #e5e7eb;
-    --text-primary: #111827;
-    --text-secondary: #6b7280;
-    --text-muted: #9ca3af;
-    --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-    --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
-    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-    --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
-    --radius: 8px;
-    --radius-lg: 12px;
-    --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    /* brand gradient */
+    --grad-1: #6366f1;
+    --grad-2: #a855f7;
+    --grad-3: #22d3ee;
+    --brand-gradient: linear-gradient(120deg, var(--grad-1), var(--grad-2) 45%, var(--grad-3));
+
+    --radius: 14px;
+    --radius-lg: 22px;
+    --radius-pill: 999px;
+
+    --font-display: 'Sora', 'Inter', system-ui, sans-serif;
+    --font-body: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    --font-mono: 'JetBrains Mono', ui-monospace, monospace;
+
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+    --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
-/* Reset and Base Styles */
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+/* ---------- Dark theme (default) ---------- */
+[data-theme="dark"] {
+    --bg: #07070d;
+    --bg-2: #0c0c16;
+    --surface: rgba(22, 22, 38, 0.55);
+    --surface-solid: #14141f;
+    --surface-hover: rgba(40, 40, 66, 0.65);
+    --border: rgba(255, 255, 255, 0.09);
+    --border-strong: rgba(255, 255, 255, 0.18);
+    --text: #f2f3f8;
+    --text-soft: #b6b9c8;
+    --text-muted: #767a8d;
+    --shadow-color: 0 0 0;
+    --glass-blur: 18px;
+    --glow: 0 0 40px -8px var(--grad-2);
+    --canvas-line: rgba(140, 130, 255, 0.5);
+    --canvas-dot: rgba(180, 160, 255, 0.9);
+    --grain-opacity: 0.04;
 }
 
-html {
-    font-size: 16px;
-    scroll-behavior: smooth;
+/* ---------- Light theme ---------- */
+[data-theme="light"] {
+    --bg: #f4f5fb;
+    --bg-2: #eceefa;
+    --surface: rgba(255, 255, 255, 0.7);
+    --surface-solid: #ffffff;
+    --surface-hover: rgba(255, 255, 255, 0.95);
+    --border: rgba(20, 20, 50, 0.08);
+    --border-strong: rgba(20, 20, 50, 0.16);
+    --text: #14152a;
+    --text-soft: #4a4d63;
+    --text-muted: #888ba0;
+    --shadow-color: 90 95 160;
+    --glass-blur: 16px;
+    --glow: 0 0 40px -10px var(--grad-1);
+    --canvas-line: rgba(99, 102, 241, 0.35);
+    --canvas-dot: rgba(120, 90, 230, 0.6);
+    --grain-opacity: 0.025;
 }
+
+/* ---------- Reset ---------- */
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+html { font-size: 16px; scroll-behavior: smooth; }
 
 body {
-    font-family: var(--font-family);
+    font-family: var(--font-body);
+    background: var(--bg);
+    color: var(--text);
     line-height: 1.6;
-    color: var(--text-primary);
-    background: var(--background);
     min-height: 100vh;
-    display: flex;
-    flex-direction: column;
     overflow-x: hidden;
+    -webkit-font-smoothing: antialiased;
+    transition: background 0.5s var(--ease), color 0.4s var(--ease);
 }
 
-/* Typography */
-h1, h2, h3 {
-    font-weight: 600;
-    line-height: 1.2;
+h1, h2, h3, h4 { font-family: var(--font-display); font-weight: 700; line-height: 1.15; }
+a { color: inherit; text-decoration: none; }
+button { font-family: inherit; cursor: pointer; }
+svg { display: block; }
+.hidden { display: none !important; }
+
+/* Lucide icons sizing */
+[data-lucide], .lucide { width: 1.15em; height: 1.15em; stroke-width: 2; }
+
+/* ============================================================
+   Animated background
+   ============================================================ */
+#bg-canvas {
+    position: fixed; inset: 0;
+    width: 100%; height: 100%;
+    z-index: 0; pointer-events: none;
 }
 
-/* App Layout */
+.aurora { position: fixed; inset: 0; z-index: -1; overflow: hidden; pointer-events: none; }
+.aurora-blob {
+    position: absolute;
+    width: 55vmax; height: 55vmax;
+    border-radius: 50%;
+    filter: blur(90px);
+    opacity: 0.5;
+    mix-blend-mode: screen;
+    animation: drift 24s ease-in-out infinite alternate;
+}
+[data-theme="light"] .aurora-blob { opacity: 0.32; mix-blend-mode: multiply; }
+.blob-1 { background: radial-gradient(circle, var(--grad-1), transparent 65%); top: -18%; left: -12%; }
+.blob-2 { background: radial-gradient(circle, var(--grad-2), transparent 65%); bottom: -20%; right: -10%; animation-delay: -8s; }
+.blob-3 { background: radial-gradient(circle, var(--grad-3), transparent 65%); top: 30%; left: 45%; animation-delay: -15s; }
+
+@keyframes drift {
+    0%   { transform: translate(0, 0) scale(1); }
+    50%  { transform: translate(6%, -8%) scale(1.15); }
+    100% { transform: translate(-7%, 9%) scale(0.95); }
+}
+
+.grain {
+    position: fixed; inset: 0; z-index: 1; pointer-events: none;
+    opacity: var(--grain-opacity);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* ============================================================
+   Top bar
+   ============================================================ */
+.topbar {
+    position: sticky; top: 0; z-index: 50;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 1rem clamp(1rem, 4vw, 3rem);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    background: linear-gradient(to bottom, var(--bg) 10%, transparent);
+}
+.brand { display: flex; align-items: center; gap: 0.6rem; font-family: var(--font-display); font-weight: 800; font-size: 1.25rem; letter-spacing: -0.02em; }
+.brand-mark {
+    display: grid; place-items: center;
+    width: 38px; height: 38px; border-radius: 11px;
+    background: var(--brand-gradient);
+    color: #fff; box-shadow: var(--glow);
+    animation: floaty 5s ease-in-out infinite;
+}
+.brand-mark [data-lucide] { width: 20px; height: 20px; }
+.brand-accent { background: var(--brand-gradient); -webkit-background-clip: text; background-clip: text; color: transparent; }
+
+@keyframes floaty { 0%,100% { transform: translateY(0) rotate(0); } 50% { transform: translateY(-4px) rotate(-4deg); } }
+
+.controls { display: flex; align-items: center; gap: 0.5rem; }
+.ctrl-btn {
+    display: inline-flex; align-items: center; gap: 0.4rem;
+    height: 42px; padding: 0 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-pill);
+    background: var(--surface);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+    color: var(--text-soft);
+    transition: all 0.25s var(--ease);
+}
+.ctrl-btn:hover { color: var(--text); border-color: var(--border-strong); transform: translateY(-2px); box-shadow: 0 8px 24px -10px rgb(var(--shadow-color) / 0.5); }
+.ctrl-btn [data-lucide] { width: 18px; height: 18px; }
+.ctrl-label { font-weight: 600; font-size: 0.85rem; }
+
+/* theme icon swap */
+[data-theme="dark"] .icon-light { display: none; }
+[data-theme="light"] .icon-dark { display: none; }
+
+/* ============================================================
+   App layout
+   ============================================================ */
 .app {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 2rem 1rem;
-    min-height: 100vh;
+    position: relative; z-index: 2;
+    max-width: 920px; margin: 0 auto;
+    padding: clamp(1.5rem, 4vw, 3rem) clamp(1rem, 4vw, 2rem) 4rem;
+    display: flex; flex-direction: column; align-items: center;
 }
 
-/* Header */
-.header {
-    text-align: center;
-    margin-bottom: 3rem;
+/* ---------- Hero ---------- */
+.hero { text-align: center; margin: clamp(1rem, 4vw, 3rem) 0 2.5rem; animation: rise 0.8s var(--ease) both; }
+.hero-badge {
+    display: inline-flex; align-items: center; gap: 0.5rem;
+    padding: 0.4rem 0.95rem; margin-bottom: 1.4rem;
+    border: 1px solid var(--border); border-radius: var(--radius-pill);
+    background: var(--surface); backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+    font-size: 0.8rem; font-weight: 600; color: var(--text-soft); letter-spacing: 0.01em;
 }
+.pulse-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--grad-3); box-shadow: 0 0 0 0 var(--grad-3); animation: pulseDot 2s infinite; }
+@keyframes pulseDot { 0% { box-shadow: 0 0 0 0 rgb(34 211 238 / 0.6); } 70% { box-shadow: 0 0 0 9px rgb(34 211 238 / 0); } 100% { box-shadow: 0 0 0 0 rgb(34 211 238 / 0); } }
 
-.logo {
-    font-size: 3rem;
-    font-weight: 700;
-    color: var(--text-primary);
-    margin-bottom: 0.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
+.hero-title { font-size: clamp(2.6rem, 8vw, 4.6rem); font-weight: 800; letter-spacing: -0.04em; }
+.grad-text {
+    background: var(--brand-gradient); background-size: 200% auto;
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+    animation: shimmer 6s linear infinite;
 }
+@keyframes shimmer { to { background-position: 200% center; } }
 
-.logo-icon {
-    font-size: 3rem;
-    animation: float 3s ease-in-out infinite;
-}
+.hero-tagline { margin-top: 1rem; font-size: clamp(1.05rem, 2.5vw, 1.3rem); color: var(--text-soft); max-width: 36ch; margin-inline: auto; }
+.hero-sub { margin-top: 0.5rem; font-size: 0.95rem; color: var(--text-muted); max-width: 48ch; margin-inline: auto; }
 
-@keyframes float {
-    0%, 100% { transform: translateY(0px); }
-    50% { transform: translateY(-10px); }
-}
+@keyframes rise { from { opacity: 0; transform: translateY(26px); } to { opacity: 1; transform: translateY(0); } }
 
-.tagline {
-    font-size: 1.1rem;
-    color: var(--text-secondary);
-    font-weight: 400;
-    font-style: italic;
-}
-
-/* Search Container */
-.search-container {
-    width: 100%;
-    max-width: 600px;
+/* ============================================================
+   Glass cards
+   ============================================================ */
+.glass {
     background: var(--surface);
+    backdrop-filter: blur(var(--glass-blur)) saturate(140%);
+    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(140%);
+    border: 1px solid var(--border);
     border-radius: var(--radius-lg);
-    padding: 2.5rem;
-    box-shadow: var(--shadow-lg);
-    border: 1px solid var(--border);
+    box-shadow: 0 24px 60px -28px rgb(var(--shadow-color) / 0.55);
 }
 
-/* Input Group */
-.input-group {
-    position: relative;
-    margin-bottom: 2rem;
+.search-card {
+    width: 100%; padding: clamp(1.5rem, 4vw, 2.5rem);
+    position: relative; overflow: hidden;
+    animation: rise 0.9s var(--ease) 0.1s both;
+}
+.search-card::before {
+    content: ''; position: absolute; inset: 0; padding: 1px; border-radius: inherit;
+    background: linear-gradient(135deg, rgb(255 255 255 / 0.22), transparent 40%);
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor; mask-composite: exclude; pointer-events: none;
 }
 
+/* ---------- Input ---------- */
+.input-group { position: relative; margin-bottom: 1.75rem; }
+.input-icon { position: absolute; left: 1.1rem; top: 50%; transform: translateY(-50%); width: 20px; height: 20px; color: var(--text-muted); pointer-events: none; transition: color 0.3s; }
 .query-input {
-    width: 100%;
-    padding: 1rem 1.25rem;
-    font-size: 1.1rem;
-    border: 2px solid var(--border);
-    border-radius: var(--radius);
-    background: var(--background);
-    color: var(--text-primary);
-    font-family: var(--font-family);
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    outline: none;
+    width: 100%; padding: 1.15rem 3.2rem 1.15rem 3rem;
+    font-size: 1.15rem; font-family: var(--font-body);
+    color: var(--text); background: var(--surface-solid);
+    border: 2px solid var(--border); border-radius: var(--radius);
+    outline: none; transition: all 0.3s var(--ease);
 }
+[data-theme="dark"] .query-input { background: rgba(0,0,0,0.25); }
+.query-input::placeholder { color: var(--text-muted); }
+.query-input:focus { border-color: transparent; box-shadow: 0 0 0 2px var(--grad-2), 0 0 30px -6px var(--grad-2); }
+.query-input:focus ~ .input-icon, .input-group:focus-within .input-icon { color: var(--grad-2); }
 
-.query-input:focus {
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgb(0 112 243 / 0.1);
+.clear-btn {
+    position: absolute; right: 1rem; top: 50%; transform: translateY(-50%);
+    display: grid; place-items: center; width: 30px; height: 30px;
+    border: none; border-radius: 50%; background: var(--surface-hover); color: var(--text-soft);
+    transition: all 0.2s;
 }
+.clear-btn:hover { background: var(--grad-2); color: #fff; }
+.clear-btn [data-lucide] { width: 16px; height: 16px; }
 
-.query-input::placeholder {
-    color: var(--text-muted);
-}
-
-/* Typing Cursor Animation */
 .typing-cursor {
-    position: absolute;
-    right: 1.25rem;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 2px;
-    height: 1.2rem;
-    background: var(--primary-color);
-    opacity: 0;
-    animation: blink 1s infinite;
+    position: absolute; right: 1.2rem; top: 50%; transform: translateY(-50%);
+    width: 2px; height: 1.4rem; background: var(--grad-3); opacity: 0;
 }
+.typing-cursor.active { opacity: 1; animation: blink 1s steps(2) infinite; }
+@keyframes blink { 50% { opacity: 0; } }
 
-.typing-cursor.active {
-    opacity: 1;
+/* ---------- Engines head ---------- */
+.engines-head { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 0.9rem; flex-wrap: wrap; }
+.engines-head h3 { font-size: 0.95rem; font-weight: 600; color: var(--text-soft); }
+.surprise-btn {
+    display: inline-flex; align-items: center; gap: 0.4rem;
+    padding: 0.45rem 0.85rem; border: 1px solid var(--border); border-radius: var(--radius-pill);
+    background: transparent; color: var(--text-soft); font-size: 0.82rem; font-weight: 600;
+    transition: all 0.25s var(--ease);
 }
+.surprise-btn:hover { color: var(--text); border-color: var(--grad-2); box-shadow: 0 0 18px -6px var(--grad-2); }
+.surprise-btn [data-lucide] { width: 16px; height: 16px; }
+.surprise-btn:hover [data-lucide] { animation: roll 0.6s var(--ease); }
+@keyframes roll { from { transform: rotate(0); } to { transform: rotate(360deg); } }
 
-@keyframes blink {
-    0%, 50% { opacity: 1; }
-    51%, 100% { opacity: 0; }
+/* ---------- Category tabs ---------- */
+.category-tabs { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1.25rem; }
+.cat-tab {
+    display: inline-flex; align-items: center; gap: 0.4rem;
+    padding: 0.5rem 0.9rem; border: 1px solid var(--border); border-radius: var(--radius-pill);
+    background: var(--surface); color: var(--text-soft);
+    font-size: 0.82rem; font-weight: 600; white-space: nowrap;
+    transition: all 0.25s var(--ease);
 }
+.cat-tab [data-lucide] { width: 15px; height: 15px; }
+.cat-tab:hover { color: var(--text); transform: translateY(-2px); }
+.cat-tab.active { color: #fff; border-color: transparent; background: var(--brand-gradient); box-shadow: var(--glow); }
 
-/* Search Engines */
-.search-engines {
-    margin-bottom: 2rem;
+/* ---------- Engine grid ---------- */
+.engine-grid {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(118px, 1fr));
+    gap: 0.7rem; margin-bottom: 1.5rem;
 }
-
-.search-engines h3 {
-    font-size: 1rem;
-    font-weight: 500;
-    margin-bottom: 1rem;
-    color: var(--text-secondary);
-}
-
-.engine-buttons {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
-    gap: 0.75rem;
-}
-
 .engine-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1rem;
-    border: 2px solid var(--border);
-    border-radius: var(--radius);
-    background: var(--background);
-    color: var(--text-secondary);
-    font-family: var(--font-family);
-    font-size: 0.9rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    outline: none;
+    --c: var(--grad-2);
+    display: flex; flex-direction: column; align-items: center; gap: 0.55rem;
+    padding: 1rem 0.6rem; border: 1px solid var(--border); border-radius: var(--radius);
+    background: var(--surface-solid); color: var(--text-soft);
+    font-size: 0.82rem; font-weight: 600; text-align: center;
+    transition: all 0.28s var(--ease); position: relative; overflow: hidden;
+    animation: pop 0.4s var(--ease-spring) both;
 }
-
-.engine-btn:hover {
-    border-color: var(--primary-color);
-    color: var(--primary-color);
-    transform: translateY(-2px);
-    box-shadow: var(--shadow);
+[data-theme="dark"] .engine-btn { background: rgba(255,255,255,0.03); }
+.engine-btn::after {
+    content: ''; position: absolute; inset: 0; opacity: 0; transition: opacity 0.3s;
+    background: radial-gradient(circle at 50% 0%, color-mix(in srgb, var(--c) 22%, transparent), transparent 70%);
 }
+.engine-btn:hover { transform: translateY(-4px); border-color: var(--c); color: var(--text); box-shadow: 0 14px 30px -16px var(--c); }
+.engine-btn:hover::after { opacity: 1; }
+.engine-btn.active { border-color: var(--c); color: var(--text); box-shadow: 0 0 0 1px var(--c), 0 12px 30px -14px var(--c); }
+.engine-btn.active::after { opacity: 1; }
+.engine-btn.active .engine-badge { box-shadow: 0 0 22px -4px var(--c); }
 
-.engine-btn.active {
-    border-color: var(--primary-color);
-    background: var(--primary-color);
-    color: white;
-    box-shadow: var(--shadow);
+.engine-badge {
+    display: grid; place-items: center; width: 42px; height: 42px;
+    border-radius: 12px; background: color-mix(in srgb, var(--c) 16%, var(--surface-solid));
+    transition: box-shadow 0.3s, transform 0.3s;
 }
+.engine-btn:hover .engine-badge { transform: scale(1.08); }
+.engine-badge img { width: 22px; height: 22px; }
+.engine-badge .monogram { font-family: var(--font-display); font-weight: 800; font-size: 1.1rem; color: var(--c); }
+.engine-name { line-height: 1.2; }
 
-.engine-icon {
-    width: 18px;
-    height: 18px;
-    flex-shrink: 0;
-}
+@keyframes pop { from { opacity: 0; transform: translateY(10px) scale(0.96); } to { opacity: 1; transform: translateY(0) scale(1); } }
 
-/* Custom URL Section */
-.custom-url-section {
-    margin-bottom: 2rem;
-}
-
-.custom-url-details {
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    overflow: hidden;
-}
-
+/* ---------- Custom URL ---------- */
+.custom-url-details { border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; margin-bottom: 1.5rem; }
 .custom-url-details summary {
-    padding: 1rem;
-    background: var(--surface);
-    cursor: pointer;
-    font-weight: 500;
-    color: var(--text-secondary);
-    list-style: none;
-    user-select: none;
-    transition: background-color 0.3s ease;
+    display: flex; align-items: center; gap: 0.5rem; padding: 0.95rem 1.1rem;
+    background: transparent; color: var(--text-soft); font-weight: 600; font-size: 0.9rem;
+    list-style: none; user-select: none; transition: background 0.25s;
 }
-
-.custom-url-details summary:hover {
-    background: var(--border);
-}
-
-.custom-url-details summary::-webkit-details-marker {
-    display: none;
-}
-
-.custom-url-details summary::before {
-    content: '▶';
-    margin-right: 0.5rem;
-    transition: transform 0.3s ease;
-}
-
-.custom-url-details[open] summary::before {
-    transform: rotate(90deg);
-}
-
+.custom-url-details summary::-webkit-details-marker { display: none; }
+.custom-url-details summary [data-lucide] { width: 17px; height: 17px; transition: transform 0.3s; }
+.custom-url-details summary:hover { background: var(--surface-hover); color: var(--text); }
+.custom-url-details[open] summary [data-lucide] { transform: rotate(-45deg); color: var(--grad-3); }
 .custom-url-input {
-    width: 100%;
-    padding: 1rem;
-    border: none;
-    outline: none;
-    font-size: 1rem;
-    font-family: var(--font-family);
-    background: var(--background);
-    border-top: 1px solid var(--border);
+    width: 100%; padding: 0.95rem 1.1rem; border: none; border-top: 1px solid var(--border);
+    background: var(--surface-solid); color: var(--text); font-family: var(--font-mono); font-size: 0.9rem; outline: none;
 }
+[data-theme="dark"] .custom-url-input { background: rgba(0,0,0,0.25); }
 
-/* Action Buttons */
-.action-buttons {
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
-}
-
+/* ---------- Action buttons ---------- */
+.action-buttons { display: flex; gap: 0.85rem; flex-wrap: wrap; }
 .search-btn {
-    flex: 1;
-    min-width: 150px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 1rem 1.5rem;
-    border: none;
-    border-radius: var(--radius);
-    font-family: var(--font-family);
-    font-size: 1rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    outline: none;
+    flex: 1; min-width: 160px;
+    display: inline-flex; align-items: center; justify-content: center; gap: 0.55rem;
+    padding: 1.05rem 1.4rem; border: none; border-radius: var(--radius);
+    font-size: 1rem; font-weight: 700; font-family: var(--font-display);
+    transition: all 0.28s var(--ease); position: relative; overflow: hidden;
 }
+.search-btn [data-lucide] { width: 19px; height: 19px; }
+.search-btn.primary { color: #fff; background: var(--brand-gradient); background-size: 180% auto; box-shadow: 0 14px 34px -12px var(--grad-2); }
+.search-btn.primary:hover { transform: translateY(-3px); background-position: right center; box-shadow: 0 20px 44px -12px var(--grad-2); }
+.search-btn.primary:active { transform: translateY(-1px) scale(0.99); }
+.search-btn.secondary { color: var(--text); background: var(--surface); border: 1px solid var(--border-strong); }
+.search-btn.secondary:hover { transform: translateY(-3px); border-color: var(--grad-2); box-shadow: 0 14px 30px -16px var(--grad-2); }
 
-.search-btn.primary {
-    background: var(--primary-color);
-    color: white;
-    box-shadow: var(--shadow);
-}
+/* ---------- Share result ---------- */
+.share-result { margin-top: 1.75rem; padding: 1.5rem; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface-hover); animation: slideIn 0.5s var(--ease); }
+.share-result h3 { font-size: 0.95rem; color: var(--text-soft); margin-bottom: 0.9rem; }
+.share-url-container { display: flex; gap: 0.6rem; margin-bottom: 0.9rem; }
+.share-url-input { flex: 1; padding: 0.8rem 0.9rem; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface-solid); color: var(--text); font-family: var(--font-mono); font-size: 0.82rem; outline: none; }
+.copy-btn { display: inline-flex; align-items: center; gap: 0.45rem; padding: 0.8rem 1.1rem; border: none; border-radius: var(--radius); background: var(--brand-gradient); color: #fff; font-weight: 600; font-size: 0.85rem; transition: all 0.25s var(--ease); white-space: nowrap; }
+.copy-btn [data-lucide] { width: 16px; height: 16px; }
+.copy-btn:hover { transform: translateY(-2px); box-shadow: 0 10px 24px -10px var(--grad-2); }
+.copy-btn.copied { background: linear-gradient(120deg, #10b981, #22d3ee); }
+.share-description { font-size: 0.85rem; color: var(--text-muted); }
 
-.search-btn.primary:hover {
-    background: var(--primary-hover);
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-lg);
-}
+@keyframes slideIn { from { opacity: 0; transform: translateY(-16px); } to { opacity: 1; transform: translateY(0); } }
 
-.search-btn.secondary {
-    background: var(--background);
-    color: var(--text-secondary);
-    border: 2px solid var(--border);
-}
+/* ============================================================
+   Features
+   ============================================================ */
+.features { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; width: 100%; margin-top: 1.75rem; }
+.feature-card { padding: 1.5rem; transition: transform 0.3s var(--ease), border-color 0.3s; }
+.feature-card:hover { transform: translateY(-4px); border-color: var(--border-strong); }
+.feature-ico { display: grid; place-items: center; width: 46px; height: 46px; border-radius: 13px; background: color-mix(in srgb, var(--grad-2) 16%, transparent); color: var(--grad-3); margin-bottom: 0.9rem; }
+.feature-ico [data-lucide] { width: 22px; height: 22px; }
+.feature-card h4 { font-size: 1.05rem; margin-bottom: 0.4rem; }
+.feature-card p { font-size: 0.9rem; color: var(--text-muted); line-height: 1.55; }
 
-.search-btn.secondary:hover {
-    border-color: var(--primary-color);
-    color: var(--primary-color);
-    transform: translateY(-2px);
-    box-shadow: var(--shadow);
-}
+/* ============================================================
+   Footer
+   ============================================================ */
+.footer { margin-top: 3rem; text-align: center; color: var(--text-muted); }
+.footer p { font-size: 0.9rem; }
+.footer-sub { margin-top: 0.5rem; font-size: 0.82rem; display: flex; align-items: center; justify-content: center; gap: 0.35rem; }
+.footer-sub a { color: var(--text-soft); border-bottom: 1px dashed var(--border-strong); transition: color 0.2s; }
+.footer-sub a:hover { color: var(--grad-3); }
+.footer .heart { width: 14px; height: 14px; color: #f43f5e; fill: #f43f5e; animation: heartbeat 1.4s ease-in-out infinite; }
+@keyframes heartbeat { 0%,100% { transform: scale(1); } 25% { transform: scale(1.22); } 40% { transform: scale(1); } }
 
-.btn-icon {
-    font-size: 1.1rem;
-}
+/* ============================================================
+   Overlays: loading + success
+   ============================================================ */
+.overlay { position: fixed; inset: 0; z-index: 9999; display: grid; place-items: center; animation: fadeOverlay 0.4s var(--ease); }
+@keyframes fadeOverlay { from { opacity: 0; } to { opacity: 1; } }
 
-/* Share Result */
-.share-result {
-    margin-top: 2rem;
-    padding: 1.5rem;
-    background: var(--background);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    animation: slideIn 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-}
+.loading-screen { background: radial-gradient(circle at 50% 40%, var(--bg-2), var(--bg) 70%); }
+.loading-content { text-align: center; color: var(--text); }
 
-.share-result h3 {
-    font-size: 1rem;
-    font-weight: 500;
-    margin-bottom: 1rem;
-    color: var(--text-secondary);
-}
-
-.share-url-container {
-    display: flex;
-    gap: 0.5rem;
-    margin-bottom: 1rem;
-}
-
-.share-url-input {
-    flex: 1;
-    padding: 0.75rem;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    background: var(--surface);
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.875rem;
-    color: var(--text-primary);
-    outline: none;
-}
-
-.copy-btn {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1rem;
-    background: var(--primary-color);
-    color: white;
-    border: none;
-    border-radius: var(--radius);
-    font-family: var(--font-family);
-    font-size: 0.875rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    outline: none;
-}
-
-.copy-btn:hover {
-    background: var(--primary-hover);
-    transform: translateY(-1px);
-}
-
-.copy-btn.copied {
-    background: var(--success-color);
-}
-
-.share-description {
-    font-size: 0.875rem;
-    color: var(--text-muted);
-    font-style: italic;
-}
-
-/* Footer */
-.footer {
-    margin-top: 3rem;
-    text-align: center;
-    color: var(--text-muted);
-    font-size: 0.875rem;
-    font-style: italic;
-}
-
-/* Loading Screen */
-.loading-screen {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(135deg, #1e3a8a 0%, #3730a3 100%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 9999;
-}
-
-.loading-content {
-    text-align: center;
-    color: white;
-}
-
-.search-animation {
-    position: relative;
-    width: 200px;
-    height: 200px;
-    margin: 0 auto 2rem;
-}
-
+.search-animation { position: relative; width: 220px; height: 220px; margin: 0 auto 2rem; }
 .radar {
-    width: 200px;
-    height: 200px;
-    border: 2px solid rgba(255, 255, 255, 0.2);
-    border-radius: 50%;
-    position: relative;
-    animation: pulse 2s ease-in-out infinite;
+    position: absolute; inset: 0; border-radius: 50%;
+    border: 2px solid var(--border-strong);
+    box-shadow: inset 0 0 60px -20px var(--grad-2);
+}
+.radar::before, .radar::after { content: ''; position: absolute; border: 1px solid var(--border); border-radius: 50%; }
+.radar::before { inset: 28px; }
+.radar::after { inset: 60px; }
+.radar-sweep {
+    position: absolute; inset: 0; border-radius: 50%;
+    background: conic-gradient(from 0deg, transparent 0deg, color-mix(in srgb, var(--grad-2) 55%, transparent) 60deg, transparent 70deg);
+    animation: sweep 2.4s linear infinite;
+}
+@keyframes sweep { to { transform: rotate(360deg); } }
+.radar-dot { position: absolute; width: 10px; height: 10px; border-radius: 50%; background: var(--grad-3); box-shadow: 0 0 12px var(--grad-3); opacity: 0; animation: ping 2.4s ease-in-out infinite; }
+.dot-1 { top: 30%; left: 62%; animation-delay: 0.3s; }
+.dot-2 { top: 60%; left: 38%; animation-delay: 1.1s; }
+.dot-3 { top: 48%; left: 72%; animation-delay: 1.8s; }
+@keyframes ping { 0%, 100% { opacity: 0; transform: scale(0.5); } 20%, 40% { opacity: 1; transform: scale(1.3); } }
+
+#loading-text { font-size: 1.55rem; margin-bottom: 0.4rem; background: var(--brand-gradient); background-clip: text; -webkit-background-clip: text; color: transparent; }
+.loading-query { color: var(--text-muted); font-family: var(--font-mono); font-size: 0.9rem; margin-bottom: 1.6rem; min-height: 1.2em; }
+.progress-bar { width: min(320px, 70vw); height: 5px; border-radius: var(--radius-pill); background: var(--border); margin: 0 auto; overflow: hidden; }
+.progress-fill { height: 100%; width: 0; border-radius: inherit; background: var(--brand-gradient); animation: progress 4.2s var(--ease) forwards; }
+@keyframes progress { 0% { width: 0; } 60% { width: 72%; } 100% { width: 100%; } }
+
+.success-screen { background: radial-gradient(circle at 50% 40%, color-mix(in srgb, var(--grad-3) 12%, var(--bg-2)), var(--bg) 70%); }
+.success-content { text-align: center; animation: successZoom 0.8s var(--ease-spring); }
+.success-icon { display: grid; place-items: center; margin: 0 auto 1.2rem; color: #10b981; }
+.success-icon [data-lucide] { width: 96px; height: 96px; stroke-width: 2.2; filter: drop-shadow(0 0 24px rgb(16 185 129 / 0.6)); animation: bounceIn 0.7s var(--ease-spring); }
+.success-content h1 { font-size: clamp(2.2rem, 7vw, 3.4rem); letter-spacing: -0.02em; background: linear-gradient(120deg, #10b981, var(--grad-3)); background-clip: text; -webkit-background-clip: text; color: transparent; }
+.success-content p { margin-top: 0.5rem; font-size: 1.1rem; color: var(--text-soft); }
+@keyframes successZoom { 0% { opacity: 0; transform: scale(0.6); } 100% { opacity: 1; transform: scale(1); } }
+@keyframes bounceIn { 0% { transform: scale(0) rotate(-20deg); } 60% { transform: scale(1.2) rotate(6deg); } 100% { transform: scale(1) rotate(0); } }
+
+/* ============================================================
+   Toast
+   ============================================================ */
+.toast {
+    position: fixed; left: 50%; bottom: 2rem; transform: translateX(-50%) translateY(20px);
+    z-index: 12000; padding: 0.85rem 1.3rem; border-radius: var(--radius-pill);
+    background: var(--surface-solid); border: 1px solid var(--border-strong); color: var(--text);
+    font-size: 0.9rem; font-weight: 600; box-shadow: 0 20px 50px -20px rgb(var(--shadow-color) / 0.7);
+    backdrop-filter: blur(var(--glass-blur)); -webkit-backdrop-filter: blur(var(--glass-blur));
+    opacity: 0; transition: all 0.35s var(--ease-spring);
+}
+.toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+
+/* ============================================================
+   Responsive
+   ============================================================ */
+@media (max-width: 560px) {
+    .engine-grid { grid-template-columns: repeat(auto-fill, minmax(96px, 1fr)); gap: 0.55rem; }
+    .engine-btn { padding: 0.8rem 0.4rem; font-size: 0.74rem; }
+    .engine-badge { width: 38px; height: 38px; }
+    .action-buttons { flex-direction: column; }
+    .search-btn { min-width: unset; }
+    .share-url-container { flex-direction: column; }
+    .brand-name { font-size: 1.05rem; }
+    .ctrl-label { display: none; }
 }
 
-.radar::before,
-.radar::after {
-    content: '';
-    position: absolute;
-    border: 2px solid rgba(255, 255, 255, 0.1);
-    border-radius: 50%;
-}
-
-.radar::before {
-    width: 150px;
-    height: 150px;
-    top: 23px;
-    left: 23px;
-    animation: pulse 2s ease-in-out infinite 0.5s;
-}
-
-.radar::after {
-    width: 100px;
-    height: 100px;
-    top: 48px;
-    left: 48px;
-    animation: pulse 2s ease-in-out infinite 1s;
-}
-
-.scanning-line {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 2px;
-    height: 80px;
-    background: linear-gradient(to bottom, transparent, #00f5ff, transparent);
-    transform-origin: bottom;
-    animation: scan 3s linear infinite;
-}
-
-@keyframes pulse {
-    0%, 100% {
-        transform: scale(1);
-        opacity: 1;
-    }
-    50% {
-        transform: scale(1.1);
-        opacity: 0.5;
-    }
-}
-
-@keyframes scan {
-    0% {
-        transform: translate(-50%, -50%) rotate(0deg);
-    }
-    100% {
-        transform: translate(-50%, -50%) rotate(360deg);
-    }
-}
-
-#loading-text {
-    font-size: 1.5rem;
-    font-weight: 600;
-    margin-bottom: 1rem;
-    animation: textPulse 2s ease-in-out infinite;
-}
-
-@keyframes textPulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.7; }
-}
-
-.progress-bar {
-    width: 300px;
-    height: 4px;
-    background: rgba(255, 255, 255, 0.2);
-    border-radius: 2px;
-    margin: 0 auto;
-    overflow: hidden;
-}
-
-.progress-fill {
-    height: 100%;
-    background: linear-gradient(90deg, #00f5ff, #0070f3);
-    border-radius: 2px;
-    animation: progress 4s ease-in-out infinite;
-}
-
-@keyframes progress {
-    0% {
-        width: 0%;
-        margin-left: 0%;
-    }
-    50% {
-        width: 70%;
-        margin-left: 15%;
-    }
-    100% {
-        width: 100%;
-        margin-left: 0%;
-    }
-}
-
-/* Success Screen */
-.success-screen {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(135deg, #059669 0%, #10b981 100%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 10000;
-}
-
-.success-content {
-    text-align: center;
-    color: white;
-    animation: successZoom 1s cubic-bezier(0.175, 0.885, 0.32, 1.275);
-}
-
-.success-icon {
-    font-size: 6rem;
-    margin-bottom: 1rem;
-    animation: bounce 1s ease-in-out;
-}
-
-.success-content h1 {
-    font-size: 3rem;
-    font-weight: 700;
-    margin-bottom: 1rem;
-    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-}
-
-.success-content p {
-    font-size: 1.2rem;
-    opacity: 0.9;
-}
-
-@keyframes successZoom {
-    0% {
-        transform: scale(0);
-        opacity: 0;
-    }
-    50% {
-        transform: scale(1.1);
-    }
-    100% {
-        transform: scale(1);
-        opacity: 1;
-    }
-}
-
-@keyframes bounce {
-    0%, 20%, 53%, 80%, 100% {
-        transform: translate3d(0, 0, 0);
-    }
-    40%, 43% {
-        transform: translate3d(0, -20px, 0);
-    }
-    70% {
-        transform: translate3d(0, -10px, 0);
-    }
-    90% {
-        transform: translate3d(0, -4px, 0);
-    }
-}
-
-/* Utility Classes */
-.hidden {
-    display: none !important;
-}
-
-.fade-in {
-    animation: fadeIn 0.5s ease-in-out;
-}
-
-@keyframes fadeIn {
-    from { opacity: 0; transform: translateY(20px); }
-    to { opacity: 1; transform: translateY(0); }
-}
-
-@keyframes slideIn {
-    from { opacity: 0; transform: translateY(-20px); }
-    to { opacity: 1; transform: translateY(0); }
-}
-
-/* Responsive Design */
-@media (max-width: 768px) {
-    .app {
-        padding: 1rem;
-    }
-    
-    .logo {
-        font-size: 2.5rem;
-    }
-    
-    .logo-icon {
-        font-size: 2.5rem;
-    }
-    
-    .search-container {
-        padding: 2rem 1.5rem;
-    }
-    
-    .engine-buttons {
-        grid-template-columns: repeat(2, 1fr);
-    }
-    
-    .action-buttons {
-        flex-direction: column;
-    }
-    
-    .search-btn {
-        min-width: unset;
-    }
-    
-    .share-url-container {
-        flex-direction: column;
-    }
-    
-    .success-content h1 {
-        font-size: 2.5rem;
-    }
-    
-    .success-icon {
-        font-size: 5rem;
-    }
-}
-
-@media (max-width: 480px) {
-    .search-container {
-        padding: 1.5rem 1rem;
-    }
-    
-    .engine-buttons {
-        grid-template-columns: 1fr;
-    }
-    
-    .logo {
-        font-size: 2rem;
-    }
-    
-    .logo-icon {
-        font-size: 2rem;
-    }
+/* ============================================================
+   Reduced motion
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; transition-duration: 0.01ms !important; scroll-behavior: auto !important; }
+    .aurora-blob, #bg-canvas { display: none; }
 }


### PR DESCRIPTION
## 🔍 Full redesign of SearchForYou

A complete creative overhaul of the project into a polished, cinematic, privacy-first search portal — ready to shine on GitHub Pages.

### ✨ What's new

**Design**
- 🌑 **Dark theme by default** with a polished **light theme** (choice persisted in `localStorage`)
- Glassmorphism cards, animated brand gradient, drifting aurora blobs
- 🪐 **Animated, mouse-reactive node-network background** on `<canvas>`
- Revamped **shared-link sequence**: typing animation → radar sweep with pinging detections → "ANSWER FOUND!" success → redirect

**Search engines (31 across 6 categories)**
- **Mainstream:** Google, Bing, Yandex, DuckDuckGo, Baidu
- **Privacy:** Brave, Startpage, Ecosia, Qwant, Mojeek, SearXNG, Swisscows
- **AI:** Perplexity, Phind, You.com, Andi
- **Academic:** Wikipedia, WolframAlpha, Scholar, arXiv, Semantic Scholar, PubMed
- **Indie / Old Web:** Marginalia, Wiby, Stract, Yep, Million Short, Presearch
- **Developer:** GitHub, Stack Overflow, MDN, DevDocs, Hacker News
- Category tabs, **"Surprise me"** engine roulette, brand-colored badges with graceful monogram fallback

**Internationalization**
- Full **English + Russian** UI with an instant language switch (`i18n.js`)

**Icons & polish**
- [Lucide](https://lucide.dev) for UI icons + [Simple Icons](https://simpleicons.org) for authentic engine logos (CDN)
- Toasts, clear button, `/` keyboard shortcut to focus search, native share on mobile
- PWA `manifest.json`, `prefers-reduced-motion` support, fully responsive

**Docs**
- README rewritten in **English** (with engine table, deployment & customization guides)
- Added `CONTRIBUTING.md`

### 🗂️ Structure
Split into focused files: `index.html`, `styles.css`, `script.js`, `engines.js`, `i18n.js`, `manifest.json` — still **zero build step**, pure static.

### ✅ Verification
Rendered headless (Playwright/Chromium): **no console/page errors**, both themes and both languages verified, category filtering and shared-link animation confirmed working. *(Brand-logo CDNs are blocked in the sandbox, so screenshots show the monogram fallback — real logos load on GitHub Pages.)*

https://claude.ai/code/session_01RQona1zGwQS1AaMZQDrVU3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQona1zGwQS1AaMZQDrVU3)_